### PR TITLE
ci: Fix push error by checking out pull request branch

### DIFF
--- a/.github/workflows/ruff_ty_check.yml
+++ b/.github/workflows/ruff_ty_check.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          # For pull requests, check out the head ref (the source branch).
+          # For other events (like push), check out the event's ref.
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
           fetch-depth: 0
 
       # 2️⃣ Figure out which *.py files changed --------------------------------


### PR DESCRIPTION
The `ruff_ty_check` workflow was failing on pull requests because the `git push` command was executed in a "detached HEAD" state. This is the default behavior for `actions/checkout` on `pull_request` triggers.

This commit modifies the checkout step to explicitly use `github.head_ref`. This ensures the job checks out the actual source branch of the pull request, allowing the auto-format commit to be pushed successfully.