### PR TITLE
feat: Add block timeline generator and bay usage analyzer

### DIFF
--- a/scripts/block_and_bay_tools/bay_usage_analyzer.py
+++ b/scripts/block_and_bay_tools/bay_usage_analyzer.py
@@ -1,0 +1,503 @@
+"""Detect transit-cluster and stop-level scheduling conflicts.
+
+The script analyzes block-level transit data to flag times when more
+buses are scheduled than a bay or cluster can physically handle.  It
+reads the *Step 1* block-level XLSX outputs, calculates capacity
+constraints from the user-defined ``CLUSTER_DEFINITIONS``, and writes a
+detailed Excel workbook for each cluster showing every event and
+highlighting any conflicts.
+
+Typical use is from a Jupyter Notebook or ArcGIS Pro “Python” pane, but
+the module can also be invoked directly from the command line.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional, Set, Tuple
+
+import pandas as pd
+from openpyxl.styles import Font
+from pandas import DataFrame
+
+# ==================================================================================================
+# CONFIGURATION
+# ==================================================================================================
+
+# Folder containing your block-level XLSX files from Step 1
+BLOCK_OUTPUT_FOLDER: str = r"\\Path\To\Your\Input_Folder"
+
+# Where to save the cluster-conflict outputs
+CLUSTER_CONFLICT_OUTPUT_FOLDER: str = r"\\Path\To\Your\Output_Folder"
+
+# Dictionary of clusters, including single_bay, double_bay, triple_bay, and overflow.
+# Each key is the cluster name, the value is a dict with lists:
+#   'single_bay_stops' -> capacity 1 each
+#   'double_bay_stops' -> capacity 2 each
+#   'triple_bay_stops' -> capacity 3 each
+#   'overflow_bays'    -> capacity 1 each
+CLUSTER_DEFINITIONS: Dict[str, Dict[str, List[str]]] = {
+    "Park & Ride": {
+        "single_bay_stops": ["3882", "3881"],
+        "double_bay_stops": [],
+        "triple_bay_stops": [],
+        "overflow_bays": [],
+    },
+    "Metro": {
+        "single_bay_stops": ["2373"],
+        "double_bay_stops": ["2832"],
+        "triple_bay_stops": [],
+        "overflow_bays": ["layover_bay_A", "layover_bay_B"],
+    },
+}
+
+# Define which statuses indicate bus presence in the cluster
+PRESENCE_STATUSES: Set[str] = {
+    "ARRIVE",
+    "DEPART",
+    "ARRIVE/DEPART",
+    "DWELL",
+    "LOADING",
+    "LAYOVER",
+    "LONG BREAK",
+}
+
+# Define which statuses indicate the bus is physically occupying a stop bay
+PASSENGER_SERVICE_STATUSES: Set[str] = {
+    "ARRIVE",
+    "DEPART",
+    "ARRIVE/DEPART",
+    "LOADING",
+}
+
+# ==================================================================================================
+# FUNCTIONS
+# ==================================================================================================
+
+
+def get_all_official_stops(cinfo: Dict[str, List[str]]) -> List[str]:
+    """Return a combined list of all *official* stops in a cluster.
+
+    Regardless of whether the stop is single-, double-, or triple-bay,
+    overflow bays are *excluded* here because they do not count toward
+    the “official” set used in certain analyses.
+
+    Args:
+    ----
+    cinfo :
+        The cluster-definition dictionary for a single cluster.
+
+    Returns:
+    -------
+    list[str]
+        Concatenated list of all official stop IDs.
+    """
+    return (
+        cinfo.get("single_bay_stops", [])
+        + cinfo.get("double_bay_stops", [])
+        + cinfo.get("triple_bay_stops", [])
+    )
+
+
+def build_cluster_capacities() -> Dict[str, int]:
+    """Compute total bay-capacity for every cluster.
+
+    Capacity is calculated as::
+
+        capacity = (#single * 1) + (#double * 2) + (#triple * 3) + (#overflow * 1)
+
+    Returns:
+    -------
+    dict[str, int]
+        Mapping of ``cluster_name -> capacity`` (number of buses that
+        can be simultaneously present).
+    """
+    capacities: Dict[str, int] = {}
+    for cname, cinfo in CLUSTER_DEFINITIONS.items():
+        n_single = len(cinfo.get("single_bay_stops", []))
+        n_double = len(cinfo.get("double_bay_stops", []))
+        n_triple = len(cinfo.get("triple_bay_stops", []))
+        n_overflow = len(cinfo.get("overflow_bays", []))
+
+        cluster_cap = (1 * n_single) + (2 * n_double) + (3 * n_triple) + (1 * n_overflow)
+        capacities[cname] = cluster_cap
+    return capacities
+
+
+def build_stop_capacities() -> Dict[str, int]:
+    """Generate a per-stop capacity dictionary.
+
+    Returns:
+    -------
+    dict[str, int]
+        ``{stop_id: capacity}`` where single-bay = 1, double-bay = 2,
+        triple-bay = 3, and overflow = 1.
+    """
+    stop_caps: Dict[str, int] = {}
+    for cinfo in CLUSTER_DEFINITIONS.values():
+        for stop_id in cinfo.get("single_bay_stops", []):
+            stop_caps[str(stop_id)] = 1
+        for stop_id in cinfo.get("double_bay_stops", []):
+            stop_caps[str(stop_id)] = 2
+        for stop_id in cinfo.get("triple_bay_stops", []):
+            stop_caps[str(stop_id)] = 3
+        for ovf in cinfo.get("overflow_bays", []):
+            stop_caps[str(ovf)] = 1
+    return stop_caps
+
+
+# --------------------------------------------------------------------------------------------------
+# CORE CONFLICT-DETECTION LOGIC
+# --------------------------------------------------------------------------------------------------
+
+
+def normalize_stop_id(stop_id: object) -> Optional[str]:
+    """Return a normalized stop-ID string.
+
+    Converts ``2956.0`` → ``"2956"`` and gracefully handles *NaN*.
+
+    Args:
+    ----
+    stop_id :
+        Value from the ``Stop ID`` column, potentially numeric or NaN.
+
+    Returns:
+    -------
+    str | None
+        Cleaned stop ID or *None* if ``stop_id`` is NaN.
+    """
+    if pd.isna(stop_id):
+        return None
+    sid_str = str(stop_id).strip()
+    if sid_str.endswith(".0"):
+        sid_str = sid_str[:-2]
+    return sid_str
+
+
+def assign_cluster_name(df_in: DataFrame) -> DataFrame:
+    """Add a ``ClusterName`` column indicating which cluster each stop belongs to.
+
+    If a stop appears in multiple clusters (unlikely), the first match in
+    ``CLUSTER_DEFINITIONS`` wins.
+
+    Args:
+    ----------
+    df_in :
+        Input DataFrame containing at least a ``Stop ID`` column.
+
+    Returns:
+    -------
+    pandas.DataFrame
+        Copy of ``df_in`` with the additional ``ClusterName`` column.
+    """
+    df_out = df_in.copy()
+    df_out["ClusterName"] = None
+
+    # Build a map of cluster → set(stop_ids)
+    cluster_map: Dict[str, Set[str]] = {}
+    for cname, cinfo in CLUSTER_DEFINITIONS.items():
+        official_stops = get_all_official_stops(cinfo)
+        overflow = cinfo.get("overflow_bays", [])
+        all_stops = official_stops + overflow
+        cluster_map[cname] = set(map(str, all_stops))
+
+    for cname, stop_set in cluster_map.items():
+        mask = df_out["Stop ID"].isin(stop_set)
+        df_out.loc[mask, "ClusterName"] = cname
+
+    return df_out
+
+
+def find_cluster_conflicts(df_in: DataFrame) -> Set[Tuple[str, str]]:
+    """Identify cluster-level conflicts.
+
+    A conflict occurs when the number of *present* buses exceeds the
+    cluster’s capacity at a specific timestamp.
+
+    Args:
+    ----------
+    df_in :
+        DataFrame that already contains a ``ClusterName`` column.
+
+    Returns:
+    -------
+    set[tuple[str, str]]
+        {(cluster_name, timestamp), …} representing each conflict point.
+    """
+    cluster_caps = build_cluster_capacities()
+    conflict_set: Set[Tuple[str, str]] = set()
+
+    present_df = df_in[df_in["Status"].isin(PRESENCE_STATUSES)].copy()
+    present_df = present_df.dropna(subset=["ClusterName"])  # ignore rows w/o cluster
+
+    group = present_df.groupby(["ClusterName", "Timestamp"])
+    for (cname, ts), grp in group:
+        cap = cluster_caps.get(cname, 1)
+        if len(grp) > cap:  # More vehicles than capacity
+            conflict_set.add((cname, ts))
+
+    return conflict_set
+
+
+def find_stop_conflicts(df_in: DataFrame) -> Set[Tuple[str, str]]:
+    """Identify stop-level conflicts.
+
+    A conflict occurs when the number of buses in passenger-service
+    statuses at a stop exceeds that stop’s capacity at a given timestamp.
+
+    Args:
+    ----------
+    df_in :
+        Raw DataFrame containing ``Stop ID`` and ``Status`` columns.
+
+    Returns:
+    -------
+    set[tuple[str, str]]
+        {(stop_id, timestamp), …} representing each conflict point.
+    """
+    stop_caps = build_stop_capacities()
+    conflict_set: Set[Tuple[str, str]] = set()
+
+    pass_df = df_in[df_in["Status"].isin(PASSENGER_SERVICE_STATUSES)].copy()
+    pass_df = pass_df[pass_df["Stop ID"].notna()]
+
+    group = pass_df.groupby(["Stop ID", "Timestamp"])
+    for (sid, ts), grp in group:
+        cap = stop_caps.get(sid, 1)
+        if len(grp) > cap:
+            conflict_set.add((sid, ts))
+
+    return conflict_set
+
+
+def annotate_conflicts(
+    df_in: DataFrame,
+    cluster_conflicts: Set[Tuple[str, str]],
+    stop_conflicts: Set[Tuple[str, str]],
+) -> DataFrame:
+    """Append a ``ConflictType`` column categorizing each row.
+
+    ``ConflictType`` will be one of ``{"NONE", "CLUSTER", "STOP", "BOTH"}``.
+
+    Args:
+    ----------
+    df_in :
+        Input DataFrame (must include ``ClusterName``, ``Stop ID``,
+        ``Timestamp``).
+    cluster_conflicts :
+        Set of cluster-level conflict keys as produced by
+        :func:`find_cluster_conflicts`.
+    stop_conflicts :
+        Set of stop-level conflict keys as produced by
+        :func:`find_stop_conflicts`.
+
+    Returns:
+    -------
+    pandas.DataFrame
+        Copy of ``df_in`` with the additional ``ConflictType`` column.
+    """
+    df_out = df_in.copy()
+    conflict_types: List[str] = []
+
+    for _, row in df_out.iterrows():
+        cname = row["ClusterName"]
+        ts = row["Timestamp"]
+        sid = row["Stop ID"]
+
+        has_cluster_conf = pd.notna(cname) and (cname, ts) in cluster_conflicts
+        has_stop_conf = sid is not None and (sid, ts) in stop_conflicts
+
+        if has_cluster_conf and has_stop_conf:
+            conflict_types.append("BOTH")
+        elif has_cluster_conf:
+            conflict_types.append("CLUSTER")
+        elif has_stop_conf:
+            conflict_types.append("STOP")
+        else:
+            conflict_types.append("NONE")
+
+    df_out["ConflictType"] = conflict_types
+    return df_out
+
+
+# --------------------------------------------------------------------------------------------------
+# I/O AND EXCEL WRITING LOGIC
+# --------------------------------------------------------------------------------------------------
+
+
+def gather_block_spreadsheets(block_folder: str) -> DataFrame:
+    """Read and concatenate every ``block_*.xlsx`` spreadsheet in *block_folder*.
+
+    Args:
+    ----------
+    block_folder :
+        Directory containing the Step 1 block-level output workbooks.
+
+    Returns:
+    -------
+    pandas.DataFrame
+        Combined DataFrame of all block files.
+
+    Raises:
+    ------
+    FileNotFoundError
+        If no eligible ``block_*.xlsx`` files are found.
+    """
+    all_files = [
+        f
+        for f in os.listdir(block_folder)
+        if f.lower().endswith(".xlsx") and f.startswith("block_")
+    ]
+    if not all_files:
+        raise FileNotFoundError(f"No block_*.xlsx files found in {block_folder}.")
+
+    big_df_list: List[DataFrame] = []
+    for fname in all_files:
+        path = os.path.join(block_folder, fname)
+        temp_df = pd.read_excel(path)
+        temp_df["FileName"] = fname
+        big_df_list.append(temp_df)
+
+    df_combined = pd.concat(big_df_list, ignore_index=True)
+    print(f"Loaded {len(df_combined)} total rows from Step 1 block XLSX files.")
+    return df_combined
+
+
+def run_step2_conflict_detection() -> None:
+    """Execute the full Step 2 conflict-detection workflow.
+
+    Steps
+    -----
+    1. Read block-level spreadsheets from :pydata:`BLOCK_OUTPUT_FOLDER`.
+    2. Normalise stop IDs, assign clusters, find conflicts.
+    3. For each cluster, build an Excel workbook containing:
+       * “AllStops” sheet (all events, bolding conflict rows).
+       * One sheet per stop/overflow bay (same bolding).
+    4. Print summary statistics.
+
+    Raises:
+    ------
+    ValueError
+        If required columns are missing from the input spreadsheets.
+    """
+    print("=== Step 2: Conflict detection and per-cluster output (multi-bay) ===")
+    os.makedirs(CLUSTER_CONFLICT_OUTPUT_FOLDER, exist_ok=True)
+
+    # 1) Gather Step 1 data
+    df = gather_block_spreadsheets(BLOCK_OUTPUT_FOLDER)
+
+    # Basic checks/cleanup
+    required_cols = [
+        "Timestamp",
+        "Trip ID",
+        "Block",
+        "Route",
+        "Direction",
+        "Stop ID",
+        "Stop Name",
+        "Stop Sequence",
+        "Arrival Time",
+        "Departure Time",
+        "Status",
+    ]
+    missing_cols = [c for c in required_cols if c not in df.columns]
+    if missing_cols:
+        raise ValueError(f"Missing columns in block-level data: {missing_cols}")
+
+    # Normalize Stop ID text
+    df["Stop ID"] = df["Stop ID"].apply(normalize_stop_id)
+    # Ensure string Timestamps
+    df["Timestamp"] = df["Timestamp"].astype(str).str.strip()
+
+    # 2) Assign cluster, detect conflicts, annotate
+    df = assign_cluster_name(df)
+    cluster_conflicts = find_cluster_conflicts(df)
+    stop_conflicts = find_stop_conflicts(df)
+    df_annotated = annotate_conflicts(df, cluster_conflicts, stop_conflicts)
+
+    # 3) Write results per cluster, each cluster → single XLSX with multiple sheets
+    for cname, cinfo in CLUSTER_DEFINITIONS.items():
+        # Combine all official stops + overflow for that cluster
+        official_stops = get_all_official_stops(cinfo)
+        overflow_stops = cinfo.get("overflow_bays", [])
+        all_cluster_stops = official_stops + overflow_stops
+
+        sub = df_annotated[df_annotated["ClusterName"] == cname].copy()
+        if sub.empty:
+            print(f"No rows found for cluster '{cname}'. Skipping.")
+            continue
+
+        safe_name = cname.replace(" ", "_")
+        out_path = os.path.join(
+            CLUSTER_CONFLICT_OUTPUT_FOLDER,
+            f"{safe_name}_Conflicts.xlsx",
+        )
+        print(f"Building conflict output for cluster '{cname}' → {out_path}")
+
+        # Sort by timestamp, then by block or stop ID
+        sub.sort_values(["Timestamp", "Block", "Stop ID"], inplace=True)
+
+        with pd.ExcelWriter(out_path, engine="openpyxl") as writer:
+            # 3a) “AllStops” sheet
+            sub.to_excel(writer, sheet_name="AllStops", index=False)
+
+            # Bold the conflict rows in “AllStops”
+            conflict_col_index = sub.columns.get_loc("ConflictType") + 1  # 1-based
+            worksheet_all = writer.sheets["AllStops"]
+            for row_idx in range(2, len(sub) + 2):  # data start row 2
+                conflict_val = worksheet_all.cell(
+                    row=row_idx,
+                    column=conflict_col_index,
+                ).value
+                if conflict_val != "NONE":
+                    for col_idx in range(1, len(sub.columns) + 1):
+                        cell = worksheet_all.cell(row=row_idx, column=col_idx)
+                        cell.font = Font(bold=True)
+
+            # 3b) One sheet per stop
+            for stop_id in all_cluster_stops:
+                sid_str = str(stop_id)
+                stop_df = sub[sub["Stop ID"] == sid_str].copy()
+                if stop_df.empty:
+                    continue
+
+                # Make a sheet name that is safe in Excel (≤31 chars)
+                sheet_name = f"Stop_{sid_str}"
+                if len(sheet_name) > 31:
+                    sheet_name = sheet_name[:31]
+
+                stop_df.to_excel(writer, sheet_name=sheet_name, index=False)
+
+                # Bold the conflict rows in each stop’s sheet
+                conflict_col_index_stop = stop_df.columns.get_loc("ConflictType") + 1
+                worksheet_stop = writer.sheets[sheet_name]
+                for row_idx in range(2, len(stop_df) + 2):
+                    conflict_val = worksheet_stop.cell(
+                        row=row_idx,
+                        column=conflict_col_index_stop,
+                    ).value
+                    if conflict_val != "NONE":
+                        for col_idx in range(1, len(stop_df.columns) + 1):
+                            cell = worksheet_stop.cell(row=row_idx, column=col_idx)
+                            cell.font = Font(bold=True)
+
+        print(f" → Completed writing {out_path}")
+
+    # Final conflict summary stats
+    print(f"\nDistinct cluster-conflict points: {len(cluster_conflicts)}")
+    print(f"Distinct stop-conflict points: {len(stop_conflicts)}")
+    print("Step 2 complete.")
+
+
+# ==================================================================================================
+# MAIN
+# ==================================================================================================
+
+
+def main() -> None:
+    """Entry point when executing this module as a script."""
+    run_step2_conflict_detection()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/block_and_bay_tools/gtfs_block_status_timeline.py
+++ b/scripts/block_and_bay_tools/gtfs_block_status_timeline.py
@@ -1,0 +1,860 @@
+"""Generates minute-by-minute transit block status timelines from GTFS data.
+
+Processes GTFS files to determine operational statuses (e.g., DWELL, LAYOVER, TRAVELING)
+of transit blocks at one-minute intervals, producing Excel reports for further analysis.
+
+Typically used interactively within a Jupyter notebook or ArcGIS Pro environment,
+though direct execution via the command line is also supported.
+"""
+
+import logging
+import os
+from typing import Any, Mapping, Optional, cast
+
+import pandas as pd
+
+# ==================================================================================================
+# CONFIGURATION
+# ==================================================================================================
+
+GTFS_FOLDER_PATH = r"\\your_GTFS_folder_path\here\\"
+BLOCK_OUTPUT_FOLDER = r"\\your_output_folder_path\here\\"
+
+DEFAULT_HOURS = 26
+TIME_INTERVAL_MINUTES = 1
+
+DWELL_THRESHOLD = 3  # minutes
+LAYOVER_THRESHOLD = 20  # minutes
+MAX_TRIPS_PER_BLOCK = 150
+
+CALENDAR_SERVICE_IDS = ["3"]
+
+ROUTE_SHORTNAME_FILTER: list[str] = []
+STOP_ID_FILTER: list[str] = []
+STOP_CODE_FILTER: list[str] = []
+
+CLUSTER_DEFINITIONS = {
+    "Metro": {
+        "stops": ["2956", "2955", "65", "3295", "2957", "66", "3296", "64", "63"],
+        "overflow_bays": ["OverflowA", "OverflowB", "OverflowC"],
+        "two_bay_stops": [],
+        "three_bay_stops": [],
+    },
+    "Park & Ride": {
+        "stops": ["3882", "3881", "1880"],
+        "overflow_bays": [],
+        "two_bay_stops": [],
+        "three_bay_stops": [],
+    },
+    "Metro North": {
+        "stops": ["2832", "2373"],
+        "overflow_bays": [],
+        "two_bay_stops": [],
+        "three_bay_stops": [],
+    },
+}
+
+BUS_STOP_CLUSTERS_STEP1 = [
+    {"name": name, "stops": info["stops"]} for name, info in CLUSTER_DEFINITIONS.items()
+]
+
+# ==================================================================================================
+# FUNCTIONS
+# ==================================================================================================
+
+
+def validate_folders(input_path: str, output_path: str) -> None:
+    """Check that the input folder exists, and ensure the output folder is created if not."""
+    if not os.path.isdir(input_path):
+        raise NotADirectoryError(f"Input path does not exist or is not a directory: {input_path}")
+    os.makedirs(output_path, exist_ok=True)
+
+
+# --------------------------------------------------------------------------------------------------
+# HELPER FUNCTIONS
+# --------------------------------------------------------------------------------------------------
+
+
+def time_to_minutes(time_str: str) -> int:
+    """Convert 'HH:MM:SS' or 'HH:MM' to integer minutes (e.g. "26:30:00" -> 1590)."""
+    parts = time_str.split(":")
+    hours = int(parts[0])
+    minutes = int(parts[1])
+    seconds = int(parts[2]) if len(parts) == 3 else 0
+    return hours * 60 + minutes + (seconds // 60)
+
+
+def minutes_to_hhmm(total_minutes: int) -> str:
+    """Convert integer minutes into 'HH:MM' (e.g. 1590 -> "26:30")."""
+    hours = total_minutes // 60
+    mins = total_minutes % 60
+    return f"{hours:02d}:{mins:02d}"
+
+
+def mark_first_and_last_stops(df_in: pd.DataFrame) -> pd.DataFrame:
+    """Mark each stop in the trip as the first or last using boolean columns."""
+    df_out = df_in.sort_values(["trip_id", "stop_sequence"]).copy()
+    df_out["is_first_stop"] = False
+    df_out["is_last_stop"] = False
+
+    for _, group in df_out.groupby("trip_id"):
+        min_seq_idx = group["stop_sequence"].idxmin()
+        max_seq_idx = group["stop_sequence"].idxmax()
+        df_out.loc[min_seq_idx, "is_first_stop"] = True
+        df_out.loc[max_seq_idx, "is_last_stop"] = True
+
+    return df_out
+
+
+def find_cluster(stop_id: str, bus_stop_clusters: list[dict[str, Any]]) -> Optional[str]:
+    """Given a stop_id, return the named cluster (if any) or None if not found."""
+    for cluster_item in bus_stop_clusters:
+        if stop_id in cluster_item["stops"]:
+            return cluster_item["name"]
+    return None
+
+
+# --------------------------------------------------------------------------------------------------
+# BRIDGING LOGIC REFACTOR
+# --------------------------------------------------------------------------------------------------
+
+
+def _status_for_same_trip(minute: int, stop_info: tuple) -> Optional[tuple]:
+    """Handle same-trip logic. stop_info is a tuple."""
+    (arr, dep, s_id, s_name, t_id, is_first, is_last, s_seq, t_val) = stop_info
+
+    # Check for arrive/depart/dwell
+    if minute == arr and is_last:
+        return (
+            "ARRIVE",
+            s_id,
+            s_name,
+            minutes_to_hhmm(arr),
+            minutes_to_hhmm(dep),
+            t_id,
+            s_seq,
+            t_val,
+        )
+    if minute == dep and is_first:
+        return (
+            "DEPART",
+            s_id,
+            s_name,
+            minutes_to_hhmm(arr),
+            minutes_to_hhmm(dep),
+            t_id,
+            s_seq,
+            t_val,
+        )
+    if arr == dep and minute == arr:
+        return (
+            "ARRIVE/DEPART",
+            s_id,
+            s_name,
+            minutes_to_hhmm(arr),
+            minutes_to_hhmm(dep),
+            t_id,
+            s_seq,
+            t_val,
+        )
+    if arr < minute < dep:
+        return (
+            "DWELL",
+            s_id,
+            s_name,
+            minutes_to_hhmm(arr),
+            minutes_to_hhmm(dep),
+            t_id,
+            s_seq,
+            t_val,
+        )
+    return None
+
+
+def _status_for_different_trip(
+    dep: int,
+    next_arr: int,
+    current_stop_id: str,
+    current_stop_name: str,
+    next_stop_id: str,
+    bus_stop_clusters: list[dict[str, Any]],
+) -> tuple[str, str, str]:
+    """Sub-logic for bridging between two different trips, determining LAYOVER, DEADHEAD, etc."""
+    gap = next_arr - dep
+    current_cluster = find_cluster(current_stop_id, bus_stop_clusters)
+    next_cluster = find_cluster(next_stop_id, bus_stop_clusters)
+
+    same_cluster = current_cluster and next_cluster and current_cluster == next_cluster
+    same_stop = current_stop_id == next_stop_id
+
+    if same_stop or same_cluster:
+        # Use threshold-based logic
+        if gap <= DWELL_THRESHOLD:
+            return ("DWELL", current_stop_id, current_stop_name)
+        if gap > LAYOVER_THRESHOLD:
+            return ("LONG BREAK", current_stop_id, current_stop_name)
+        return ("LAYOVER", current_stop_id, current_stop_name)
+
+    # Otherwise, different cluster => "DEADHEAD"
+    return ("DEADHEAD", current_stop_id, current_stop_name)
+
+
+def get_status_for_minute(
+    minute: int, stop_times_sequence: list[tuple], bus_stop_clusters: list[dict[str, Any]]
+) -> tuple[
+    str,
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[int],
+    int,
+]:
+    """Determine the block's status at a specific 'minute'.
+
+    Returns tuple:
+       (status, stop_id, stop_name, arrival_str, departure_str,
+        trip_id_for_status, stop_sequence, timepoint_value)
+    """
+    if not stop_times_sequence:
+        return ("EMPTY", None, None, None, None, None, None, 0)
+
+    for i, item in enumerate(stop_times_sequence):
+        same_trip_result = _status_for_same_trip(minute, item)
+        if same_trip_result:
+            return same_trip_result
+
+        # If no same-trip match, check bridging
+        arr, dep = item[0], item[1]
+        if i < len(stop_times_sequence) - 1:
+            next_item = stop_times_sequence[i + 1]
+            next_arr = next_item[0]
+            next_trip_id = next_item[4]  # we do need to return it
+            next_stop_id = next_item[2]
+            stop_id = item[2]
+            stop_name = item[3]
+            trip_id = item[4]
+            stop_seq = item[7]
+            t_val = item[8]
+
+            if dep < minute < next_arr:
+                # Check if same or different trip
+                if trip_id == next_trip_id:
+                    return (
+                        "TRAVELING BETWEEN STOPS",
+                        None,
+                        None,
+                        None,
+                        None,
+                        trip_id,
+                        None,
+                        0,
+                    )
+
+                # Different trip => dwell/layover/deadhead
+                new_status, fill_stop_id, fill_stop_name = _status_for_different_trip(
+                    dep, next_arr, stop_id, stop_name, next_stop_id, bus_stop_clusters
+                )
+                return (
+                    new_status,
+                    fill_stop_id,
+                    fill_stop_name,
+                    minutes_to_hhmm(arr),
+                    minutes_to_hhmm(dep),
+                    next_trip_id,
+                    stop_seq,
+                    t_val,
+                )
+
+    return ("EMPTY", None, None, None, None, None, None, 0)
+
+
+# --------------------------------------------------------------------------------------------------
+# MAIN BLOCK PROCESSING
+# --------------------------------------------------------------------------------------------------
+
+
+def check_for_overlapping_trips(
+    block_subset: pd.DataFrame, block_id: str
+) -> None:  # Added return type annotation
+    """Print a warning if any trips within this block overlap in time."""
+    trip_times = []
+    for trip_id, group in block_subset.groupby("trip_id"):
+        start_val = group["arrival_min"].min()
+        end_val = group["departure_min"].max()
+        trip_times.append((trip_id, start_val, end_val))
+
+    trip_times.sort(key=lambda x: x[1])
+    for i in range(len(trip_times) - 1):
+        trip1_id, start1, end1 = trip_times[i]
+        for j in range(i + 1, len(trip_times)):
+            trip2_id, start2, end2 = trip_times[j]
+            # If they intersect in any way
+            if start2 <= end1 and start1 <= end2:
+                print(
+                    f"WARNING: Overlapping trips in block {block_id}: "
+                    f"Trip {trip1_id} ({start1}–{end1}) overlaps with "
+                    f"{trip2_id} ({start2}–{end2})"
+                )
+
+
+def fill_stop_ids_for_dwell_layover_loading(
+    df_in: pd.DataFrame,
+) -> pd.DataFrame:  # Added return type annotation
+    """Fills in missing stop information for certain vehicle statuses.
+
+    For rows with a status of 'DWELL', 'LAYOVER', or 'LOADING', where the
+    'Stop ID' is typically empty, this function populates the 'Stop ID',
+    'Stop Name', 'Stop Sequence', 'Arrival Time', 'Departure Time', and
+    'Trip ID' fields. The data used for filling is based on the last known
+    stop information from the same vehicle block, enhancing the readability
+    of the final output.
+
+    Args:
+        df_in (pd.DataFrame): The input DataFrame containing vehicle status and
+            stop information.
+
+    Returns:
+        pd.DataFrame: A new DataFrame with the missing stop information filled in.
+    """
+    df_out = df_in.copy()
+    last_stop_id = None
+    last_stop_name = None
+    last_stop_seq = None
+    last_arr = None
+    last_dep = None
+    last_trip_id = None
+
+    for idx in df_out.index:
+        status = df_out.at[idx, "Status"]
+        stop_id = df_out.at[idx, "Stop ID"]
+        if stop_id:
+            # Update "last known" stop info
+            last_stop_id = stop_id
+            last_stop_name = df_out.at[idx, "Stop Name"]
+            last_stop_seq = df_out.at[idx, "Stop Sequence"]
+            last_arr = df_out.at[idx, "Arrival Time"]
+            last_dep = df_out.at[idx, "Departure Time"]
+            last_trip_id = df_out.at[idx, "Trip ID"]
+        else:
+            if status in ["DWELL", "LAYOVER", "LOADING"]:
+                if last_stop_id is not None:
+                    df_out.at[idx, "Stop ID"] = last_stop_id
+                if last_stop_name is not None:
+                    df_out.at[idx, "Stop Name"] = last_stop_name
+                if last_stop_seq is not None:
+                    df_out.at[idx, "Stop Sequence"] = last_stop_seq
+                if last_arr is not None:
+                    df_out.at[idx, "Arrival Time"] = last_arr
+                if last_dep is not None:
+                    df_out.at[idx, "Departure Time"] = last_dep
+                if last_trip_id is not None:
+                    df_out.at[idx, "Trip ID"] = last_trip_id
+    return df_out
+
+
+def _create_trips_summary(
+    block_subset: pd.DataFrame,
+) -> list[dict[str, Any]]:  # Added return type annotation
+    """Helper to build trip summaries for a block.
+
+    Returns a list of dictionaries with trip info and sorted stop times.
+    """
+    trips_summary = []
+    for trip_id, trip_df in block_subset.groupby("trip_id"):
+        trip_df_sorted = trip_df.sort_values("stop_sequence")
+        start_time = trip_df_sorted["arrival_min"].min()
+        end_time = trip_df_sorted["departure_min"].max()
+
+        stop_times_sequence = []
+        for _, row in trip_df_sorted.iterrows():
+            t_val = row.get("timepoint", 0)
+            stop_times_sequence.append(
+                (
+                    row["arrival_min"],
+                    row["departure_min"],
+                    row["stop_id"],
+                    row["stop_name"],
+                    row["trip_id"],
+                    row["is_first_stop"],
+                    row["is_last_stop"],
+                    row["stop_sequence"],
+                    t_val,
+                )
+            )
+
+        route_id = trip_df_sorted.iloc[0]["route_id"]
+        direction_id = trip_df_sorted.iloc[0]["direction_id"]
+        trips_summary.append(
+            {
+                "trip_id": trip_id,
+                "start": start_time,
+                "end": end_time,
+                "stop_times_sequence": stop_times_sequence,
+                "route_id": route_id,
+                "direction_id": direction_id,
+            }
+        )
+
+    trips_summary.sort(key=lambda x: x["start"])
+    return trips_summary
+
+
+def _status_for_active_trips(
+    minute: int,
+    active_trips: list[dict[str, Any]],
+    bus_stop_clusters: list[dict[str, Any]],
+) -> tuple[Optional[dict[str, Any]], tuple]:  # Added return type annotation
+    """Among all 'active' trips for the given minute, determine the single chosen status."""
+    candidate_info = []
+    for trip_obj in active_trips:
+        status_tuple = get_status_for_minute(
+            minute, trip_obj["stop_times_sequence"], bus_stop_clusters
+        )
+        candidate_info.append((trip_obj, status_tuple))
+
+    # Filter out actual "EMPTY" statuses
+    valid_candidates = [
+        (trip_obj, stat) for (trip_obj, stat) in candidate_info if stat[0] != "EMPTY"
+    ]
+    if not valid_candidates:
+        # All were "EMPTY"
+        return None, ("EMPTY", None, None, None, None, None, None, 0)
+
+    if len(valid_candidates) == 1:
+        return valid_candidates[0]
+
+    # Tie-break if multiple
+    def candidate_sort_key(item: tuple[dict[str, Any], tuple]) -> tuple[bool, int]:
+        stat = item[1]
+        stop_seq = stat[6] if stat[6] is not None else 999999
+        timepoint_val = stat[7] if len(stat) == 8 else 0
+        # Prefer timepoints, then lower stop_sequence
+        return (timepoint_val == 0, stop_seq)
+
+    valid_candidates.sort(key=candidate_sort_key)
+    return valid_candidates[0]
+
+
+def _row_for_inactive(
+    minute: int,
+    block_id: str,
+    all_trips: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Return a dictionary row describing the vehicle status when **no trip is active**.
+
+    The function looks at the closest finished trip and the next upcoming trip to
+    decide whether the vehicle is *DWELL*, *LAYOVER*, *LONG BREAK*, *LOADING*, or truly
+    *INACTIVE* at the requested minute.
+    """
+    prev_trip_info: Optional[dict[str, Any]] = None
+    next_trip_info: Optional[dict[str, Any]] = None
+
+    # ------------------------------------------------------------------ locate bounding trips
+    for trip_obj in all_trips:
+        # The most recent trip that has already finished
+        if trip_obj["end"] < minute:
+            if prev_trip_info is None or trip_obj["end"] > prev_trip_info["end"]:
+                prev_trip_info = trip_obj
+
+        # The very next trip that has not yet started
+        elif trip_obj["start"] > minute:
+            if next_trip_info is None or trip_obj["start"] < next_trip_info["start"]:
+                next_trip_info = trip_obj
+
+    # ------------------------------------------------------------------ status decision
+    if prev_trip_info is not None and next_trip_info is not None:
+        # Cast after the None-check so static analysers know the objects are dicts
+        prev_trip = cast("dict[str, Any]", prev_trip_info)
+        next_trip = cast("dict[str, Any]", next_trip_info)
+
+        gap: int = next_trip["start"] - prev_trip["end"]
+        if gap <= DWELL_THRESHOLD:
+            status = "DWELL"
+        elif gap <= LAYOVER_THRESHOLD:
+            status = "LAYOVER"
+        else:
+            status = "LONG BREAK"
+    else:
+        status = "INACTIVE"
+
+    # If the very next minute is the first minute of a trip, mark this minute “LOADING”.
+    if (
+        next_trip_info is not None
+        and cast("dict[str, Any]", next_trip_info)["start"] == minute + 1
+        and status in {"DWELL", "LAYOVER"}
+    ):
+        status = "LOADING"
+
+    # ------------------------------------------------------------------ final record
+    return {
+        "Timestamp": minutes_to_hhmm(minute),
+        "Block": block_id,
+        "Route": "",
+        "Direction": "",
+        "Trip ID": "",
+        "Stop ID": "",
+        "Stop Name": "",
+        "Stop Sequence": "",
+        "Arrival Time": "",
+        "Departure Time": "",
+        "Status": status,
+        "Timepoint": 0,
+    }
+
+
+def _build_schedule_rows(
+    trips_summary: list[dict[str, Any]],
+    timeline: range,
+    block_id: str,
+    bus_stop_clusters: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Create the minute-by-minute schedule rows for a single block.
+
+    Args:
+        trips_summary: Output of :func:`_create_trips_summary`.
+        timeline: Range object representing every minute to be evaluated.
+        block_id: Identifier of the vehicle block.
+        bus_stop_clusters: Cluster definitions used for dwell/layover logic.
+
+    Returns:
+        A list of dictionaries (one per minute) suitable for `pd.DataFrame`.
+    """
+    rows: list[dict[str, Any]] = []
+
+    for minute in timeline:
+        # --------------------------------------------------- identify active trips
+        possible_trips = [t for t in trips_summary if t["start"] <= minute <= t["end"]]
+
+        if possible_trips:
+            chosen_trip, chosen_status = _status_for_active_trips(
+                minute, possible_trips, bus_stop_clusters
+            )
+
+            if chosen_trip is not None:
+                chosen_trip = cast("dict[str, Any]", chosen_trip)
+
+                (
+                    status,
+                    stop_id,
+                    stop_name,
+                    arr_str,
+                    dep_str,
+                    trip_id_for_status,
+                    stop_seq,
+                    t_val,
+                ) = chosen_status
+
+                # Treat “EMPTY” as travelling between stops.
+                if status == "EMPTY":
+                    status = "TRAVELING BETWEEN STOPS"
+
+                # Convert DWELL/LAYOVER to LOADING if departure is in the next minute.
+                if status in {"DWELL", "LAYOVER"}:
+                    next_minute = minute + TIME_INTERVAL_MINUTES
+                    if next_minute <= chosen_trip["end"]:
+                        next_status = get_status_for_minute(
+                            next_minute,
+                            chosen_trip["stop_times_sequence"],
+                            bus_stop_clusters,
+                        )[0]
+                        if next_status == "DEPART":
+                            status = "LOADING"
+
+                row = {
+                    "Timestamp": minutes_to_hhmm(minute),
+                    "Block": block_id,
+                    "Route": chosen_trip["route_id"],
+                    "Direction": chosen_trip["direction_id"],
+                    "Trip ID": trip_id_for_status or "",
+                    "Stop ID": stop_id or "",
+                    "Stop Name": stop_name or "",
+                    "Stop Sequence": stop_seq or "",
+                    "Arrival Time": arr_str or "",
+                    "Departure Time": dep_str or "",
+                    "Status": status,
+                    "Timepoint": t_val,
+                }
+            else:
+                # All active trips returned “EMPTY”.
+                row = {
+                    "Timestamp": minutes_to_hhmm(minute),
+                    "Block": block_id,
+                    "Route": "",
+                    "Direction": "",
+                    "Trip ID": "",
+                    "Stop ID": "",
+                    "Stop Name": "",
+                    "Stop Sequence": "",
+                    "Arrival Time": "",
+                    "Departure Time": "",
+                    "Status": "TRAVELING BETWEEN STOPS",
+                    "Timepoint": 0,
+                }
+        else:
+            # No active trips ⇒ bridging or fully inactive.
+            row = _row_for_inactive(minute, block_id, trips_summary)
+
+        rows.append(row)
+
+    return rows
+
+
+def process_block(
+    block_subset: pd.DataFrame,
+    block_id: str,
+    timeline: range,
+    bus_stop_clusters: list[dict[str, Any]],
+) -> pd.DataFrame:
+    """Generate a minute-by-minute schedule DataFrame for a single block."""
+    trips_summary = _create_trips_summary(block_subset)
+    rows = _build_schedule_rows(trips_summary, timeline, block_id, bus_stop_clusters)
+    df = pd.DataFrame(rows)
+    return fill_stop_ids_for_dwell_layover_loading(df)
+
+
+# --------------------------------------------------------------------------------------------------
+# STEP 1: GTFS -> Block Spreadsheets
+# --------------------------------------------------------------------------------------------------
+
+
+def _merge_and_filter_data(
+    trips_df: pd.DataFrame, stop_times_df: pd.DataFrame, stops_df: pd.DataFrame
+) -> pd.DataFrame:
+    """Merge trips and stops, filter by service_id, route, etc.
+
+    Return a single merged DataFrame with arrival_min/departure_min.
+    """
+    # Filter by service_id if set
+    if CALENDAR_SERVICE_IDS:
+        trips_df = trips_df[trips_df["service_id"].isin(CALENDAR_SERVICE_IDS)]
+
+    # Convert times to minutes
+    stop_times_df["arrival_min"] = stop_times_df["arrival_time"].apply(time_to_minutes)
+    stop_times_df["departure_min"] = stop_times_df["departure_time"].apply(time_to_minutes)
+    # Keep only stop_times for the trips that survived
+    stop_times_df = stop_times_df[stop_times_df["trip_id"].isin(trips_df["trip_id"])]
+
+    # Make sure stops_df has stop_code
+    if "stop_code" not in stops_df.columns:
+        stops_df["stop_code"] = None
+
+    # Merge stop_times + trips
+    merged_df = pd.merge(stop_times_df, trips_df, on="trip_id", how="left")
+
+    # Merge with stops to get stop_name, stop_code, timepoint
+    stops_merge_cols = ["stop_id", "stop_name", "stop_code"]
+    if "timepoint" in stops_df.columns:
+        stops_merge_cols.append("timepoint")
+    merged_df = pd.merge(merged_df, stops_df[stops_merge_cols], on="stop_id", how="left")
+
+    # Mark first/last stops
+    merged_df = mark_first_and_last_stops(merged_df)
+
+    # Ensure 'timepoint' is numeric
+    if "timepoint" not in merged_df.columns:
+        merged_df["timepoint"] = 0
+    else:
+        merged_df["timepoint"] = (
+            pd.to_numeric(merged_df["timepoint"], errors="coerce").fillna(0).astype(int)
+        )
+
+    # Force first/last to timepoint=2 if it was 0
+    merged_df.loc[(merged_df["is_first_stop"]) & (merged_df["timepoint"] == 0), "timepoint"] = 2
+    merged_df.loc[(merged_df["is_last_stop"]) & (merged_df["timepoint"] == 0), "timepoint"] = 2
+
+    # Block-level filtering based on route_short_name, stop_id, stop_code
+    if ROUTE_SHORTNAME_FILTER or STOP_ID_FILTER or STOP_CODE_FILTER:
+        route_match = (
+            merged_df["route_short_name"].isin(ROUTE_SHORTNAME_FILTER)
+            if ROUTE_SHORTNAME_FILTER
+            else pd.Series(False, index=merged_df.index)
+        )
+        stopid_match = (
+            merged_df["stop_id"].astype(str).isin(STOP_ID_FILTER)
+            if STOP_ID_FILTER
+            else pd.Series(False, index=merged_df.index)
+        )
+        stopcode_match = (
+            merged_df["stop_code"].astype(str).isin(STOP_CODE_FILTER)
+            if STOP_CODE_FILTER
+            else pd.Series(False, index=merged_df.index)
+        )
+
+        row_match = route_match | stopid_match | stopcode_match
+        blocks_that_qualify = merged_df.loc[row_match, "block_id"].unique()
+        blocks_that_qualify = [b for b in blocks_that_qualify if pd.notna(b)]
+
+        block_filter_mask = merged_df["block_id"].isin(blocks_that_qualify)
+        merged_df = merged_df[block_filter_mask]
+        print(f"After filtering, total rows = {len(merged_df)}")
+    else:
+        print("No block-level filters applied.")
+
+    return merged_df
+
+
+def run_step1_gtfs_to_blocks() -> None:
+    """Step 1: Generate block-level schedules from GTFS."""
+    print("=== Step 1: Reading GTFS and generating block-level schedules ===")
+    validate_folders(GTFS_FOLDER_PATH, BLOCK_OUTPUT_FOLDER)
+
+    # Use the standardized loader
+    print("Loading GTFS data using standardized function ...")
+    gtfs_data = load_gtfs_data(GTFS_FOLDER_PATH, dtype=str)
+
+    # Pull out frames you'll need
+    trips_df = gtfs_data["trips"]
+    stop_times_df = gtfs_data["stop_times"]
+    stops_df = gtfs_data["stops"]
+
+    # Optionally handle routes
+    routes_df = gtfs_data.get("routes", None)
+    if routes_df is not None and "route_short_name" in routes_df.columns:
+        print("Merging routes.txt with trips ...")
+        if "route_short_name" not in trips_df.columns:
+            trips_df = pd.merge(
+                trips_df,
+                routes_df[["route_id", "route_short_name"]],
+                on="route_id",
+                how="left",
+            )
+    else:
+        print("WARNING: No routes.txt found or missing route_short_name column.")
+        if "route_short_name" not in trips_df.columns:
+            trips_df["route_short_name"] = None
+
+    # Now merge & filter to get the final dataset
+    merged_df = _merge_and_filter_data(trips_df, stop_times_df, stops_df)
+
+    all_blocks = merged_df["block_id"].dropna().unique()
+    print(f"Identified {len(all_blocks)} block(s) to process.")
+
+    max_minutes = DEFAULT_HOURS * 60
+    timeline = range(0, max_minutes, TIME_INTERVAL_MINUTES)
+
+    for blk_id in all_blocks:
+        print(f"\nProcessing block {blk_id}...")
+        block_data = merged_df[merged_df["block_id"] == blk_id].copy()
+        trip_ids = block_data["trip_id"].unique()
+
+        check_for_overlapping_trips(block_data, blk_id)
+
+        if len(trip_ids) > MAX_TRIPS_PER_BLOCK:
+            print(
+                f"Block {blk_id} has {len(trip_ids)} trips > limit {MAX_TRIPS_PER_BLOCK}. Skipped."
+            )
+            continue
+
+        block_schedule_df = process_block(block_data, blk_id, timeline, BUS_STOP_CLUSTERS_STEP1)
+        block_schedule_df.sort_values("Timestamp", inplace=True)
+
+        block_route_ids = block_data["route_id"].dropna().unique()
+        if len(block_route_ids) > 0:
+            block_route_str = "_".join(str(rte) for rte in block_route_ids)
+        else:
+            block_route_str = "NA"
+
+        out_name = f"block_{blk_id}_{block_route_str}.xlsx"
+        out_path = os.path.join(BLOCK_OUTPUT_FOLDER, out_name)
+        block_schedule_df.to_excel(out_path, index=False)
+        print(f"Finished block {blk_id}; saved to {out_path}")
+
+    print("\nStep 1 complete: All block-level spreadsheets generated.")
+
+
+# --------------------------------------------------------------------------------------------------
+# REUSABLE FUNCTIONS
+# --------------------------------------------------------------------------------------------------
+
+
+def load_gtfs_data(
+    gtfs_folder_path: str,
+    files: Optional[list[str]] = None,
+    dtype: str | type[str] | Mapping[str, Any] = str,
+) -> dict[str, pd.DataFrame]:
+    """Load one or more GTFS text files into a dictionary of DataFrames.
+
+    Args:
+        gtfs_folder_path (str): Absolute or relative path to the directory
+            containing GTFS text files.
+        files (list[str] | None): Explicit list of GTFS filenames to load.
+            If ``None``, the full standard GTFS set is read.
+        dtype (str | Mapping[str, Any]): Value forwarded to
+            :pyfunc:`pandas.read_csv` to control column dtypes;
+            defaults to ``str``.
+
+    Returns:
+        dict[str, pandas.DataFrame]: Mapping of file stem → DataFrame.
+        For example, ``data["trips"]`` contains *trips.txt*.
+
+    Raises:
+        OSError: The folder does not exist or a required file is missing.
+        ValueError: A file is empty or malformed.
+        RuntimeError: An OS-level error occurs while reading.
+    """
+    if not os.path.exists(gtfs_folder_path):
+        raise OSError(f"The directory '{gtfs_folder_path}' does not exist.")
+
+    if files is None:
+        files = [
+            "agency.txt",
+            "stops.txt",
+            "routes.txt",
+            "trips.txt",
+            "stop_times.txt",
+            "calendar.txt",
+            "calendar_dates.txt",
+            "fare_attributes.txt",
+            "fare_rules.txt",
+            "feed_info.txt",
+            "frequencies.txt",
+            "shapes.txt",
+            "transfers.txt",
+        ]
+
+    missing = [
+        file_name
+        for file_name in files
+        if not os.path.exists(os.path.join(gtfs_folder_path, file_name))
+    ]
+    if missing:
+        raise OSError(f"Missing GTFS files in '{gtfs_folder_path}': {', '.join(missing)}")
+
+    data = {}
+    for file_name in files:
+        key = file_name.replace(".txt", "")
+        file_path = os.path.join(gtfs_folder_path, file_name)
+        try:
+            df = pd.read_csv(file_path, dtype=dtype, low_memory=False)
+            data[key] = df
+            logging.info(f"Loaded {file_name} ({len(df)} records).")
+
+        except pd.errors.EmptyDataError as exc:
+            raise ValueError(f"File '{file_name}' in '{gtfs_folder_path}' is empty.") from exc
+
+        except pd.errors.ParserError as exc:
+            raise ValueError(
+                f"Parser error in '{file_name}' in '{gtfs_folder_path}': {exc}"
+            ) from exc
+
+        except OSError as exc:
+            raise RuntimeError(
+                f"OS error reading file '{file_name}' in '{gtfs_folder_path}': {exc}"
+            ) from exc
+    return data
+
+
+# ==================================================================================================
+# MAIN
+# ==================================================================================================
+
+
+def main() -> None:
+    """Master entry point."""
+    run_step1_gtfs_to_blocks()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds two core scripts for GTFS-based transit block analysis:

1. `gtfs_block_status_timeline.py`
   - Generates minute-by-minute status timelines (e.g., DWELL, LAYOVER, DEADHEAD) for each vehicle block.
   - Inputs GTFS files and outputs one Excel file per block.
   - Enables detailed operational QA, scheduling analysis, and bay demand studies.

2. `bay_usage_analyzer.py`
   - Ingests the block-level timeline outputs and identifies times when stop or cluster-level bay capacity is exceeded.
   - Highlights hard conflicts (capacity violations) automatically.
   - Provides full stop-by-stop occupancy timelines, enabling planners to identify high-occupancy periods manually.
   - Outputs Excel workbooks per cluster, including a full "AllStops" sheet and per-stop breakdowns with conflict annotations.

These tools form the foundation for terminal design QA, conflict detection, and broader block utilization analysis.