### PR TITLE
feat: Add OTP stop-level and trip-level runtime diagnostics scripts

### DIFF
--- a/.github/workflows/ruff_ty_check.yml
+++ b/.github/workflows/ruff_ty_check.yml
@@ -38,10 +38,20 @@ jobs:
         set -euo pipefail
         BASE_SHA="${{ github.event.pull_request.base.sha }}"
         HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+       
+        # 1. Get added / copied / modified / renamed / type‑changed *.py files.
+        CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT \
+                           "$BASE_SHA" "$HEAD_SHA" -- '*.py' | sort -u)
 
-        CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- '*.py' \
-                        | sort -u | tr '\n' ' ')
-        echo "files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
+        # 2. Keep only those paths that still exist after the checkout.
+        EXISTING_FILES=""
+        for f in $CHANGED_FILES; do
+          [[ -f "$f" ]] && EXISTING_FILES+="$f "
+        done
+
+        # 3. Publish the filtered list (trim any trailing space).
+        EXISTING_FILES=${EXISTING_FILES%% }
+        echo "files=$EXISTING_FILES" >> "$GITHUB_OUTPUT"
 
     - name: Nothing to do
       if: ${{ steps.changed.outputs.files == '' }}

--- a/scripts/operations_tools/otp_by_stop_pivot.py
+++ b/scripts/operations_tools/otp_by_stop_pivot.py
@@ -1,0 +1,354 @@
+"""Calculate OTP percentages by stop and publish user‑friendly outputs.
+
+TODO (future): GTFS‑synced visualizations (see stub at bottom).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pandas as pd
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+CSV_PATH: Path | str = (r"Path\To\Your\OTP by Timepoint.csv")
+OUTPUT_DIR: Path | str = (r"Path\To\Your\Output_Folder")
+
+OUT_SUFFIX: str = "_processed"
+
+SHORT_ROUTE_FILTER: List[str] = []
+
+TIMEPOINT_FILTER: List[str] = []
+RDT_FILTER: List[Tuple[str, str, str]] = []
+
+TIMEPOINT_ORDER: Dict[str, List[str]] = {
+    "EASTBOUND": [
+        "DULLES AIRPORT",
+        "WORLDGATE & ELDEN",
+        "HERNDON METRO STATION NORTH SIDE",
+        "RESTON TOWN CENTER METRO",
+        "WIEHE-RESTON EAST TRANSIT CTR",
+    ],
+    "WESTBOUND": [
+        "WIEHE-RESTON EAST TRANSIT CTR",
+        "RESTON TOWN CENTER METRO",
+        "HERNDON METRO STATION NORTH SIDE",
+        "WORLDGATE & ELDEN",
+        "DULLES AIRPORT",
+    ],
+}
+
+TIMEPOINT_ORDER_FILE: Path | str | None = None
+
+# -----------------------------------------------------------------------------
+# LOGGING
+# -----------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s: %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+
+# =============================================================================
+# FUNCTIONS
+# =============================================================================
+
+def build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Recalculate OTP percentages, apply optional filters, and "
+        "output pivot+summary tables."
+    )
+    p.add_argument("-i", "--input", default=CSV_PATH,
+                   help="Path to the input CSV.")
+    p.add_argument("-t", "--timepoints", nargs="*", default=TIMEPOINT_FILTER,
+                   metavar="ID", help="Time‑point IDs to keep.")
+    p.add_argument("-r", "--routes", nargs="*", default=SHORT_ROUTE_FILTER,
+                   metavar="SHORT_ROUTE", help="Short Route codes to keep.")
+    p.add_argument(
+        "-g", "--rdt", default="", type=str,
+        help=("Route,Direction,Time‑point triples separated by ';', "
+              "e.g. '151,NORTHBOUND,MHUS;152,SOUTHBOUND,MVES'.")
+    )
+    p.add_argument("-d", "--outdir", default=OUTPUT_DIR,
+                   help="Folder for all output files.")
+    p.add_argument("-o", "--output", default=None,
+                   help="Explicit output CSV path for the long table.")
+    p.add_argument("--pattern-file", default=TIMEPOINT_ORDER_FILE, type=str,
+                   metavar="JSON",
+                   help="JSON file overriding TIMEPOINT_ORDER.")
+    return p
+
+
+def parse_rdt_arg(arg: str) -> List[Tuple[str, str, str]]:
+    if not arg.strip():
+        return RDT_FILTER
+    triples: List[Tuple[str, str, str]] = []
+    for chunk in arg.split(";"):
+        parts = [p.strip() for p in chunk.split(",")]
+        if len(parts) != 3:
+            sys.exit(
+                f"ERROR: bad --rdt chunk '{chunk}'. "
+                "Use ROUTE,DIRECTION,TIMEPOINT."
+            )
+        triples.append(tuple(parts))  # type: ignore[arg-type]
+    return triples
+
+
+def make_short_route(route_str: str) -> str:
+    return route_str.split("-", 1)[0].replace(" ", "").strip()
+
+
+def recalc_percentages(df: pd.DataFrame) -> pd.DataFrame:
+    df["Total Counts"] = (
+        df["Sum # On Time"] + df["Sum # Early"] + df["Sum # Late"]
+    ).astype("Int64")
+    for pct_col, cnt_col in (
+        ("% On Time", "Sum # On Time"),
+        ("% Early", "Sum # Early"),
+        ("% Late", "Sum # Late"),
+    ):
+        df[pct_col] = (
+            df[cnt_col] / df["Total Counts"].replace(0, pd.NA) * 100
+        ).round(2)
+    return df
+
+
+def filter_basic(df: pd.DataFrame,
+                 timepoints: List[str],
+                 routes: List[str]) -> pd.DataFrame:
+    if timepoints:
+        df = df[df["Timepoint ID"].isin(timepoints)]
+    if routes:
+        df = df[df["Short Route"].isin(routes)]
+    return df
+
+
+def filter_rdt(df: pd.DataFrame,
+               triples: List[Tuple[str, str, str]]) -> pd.DataFrame:
+    if not triples:
+        return df
+    mask = False
+    for r, d, t in triples:
+        mask |= (
+            (df["Short Route"] == r)
+            & (df["Direction"].str.upper() == d.upper())
+            & (df["Timepoint ID"] == t)
+        )
+    return df[mask]
+
+
+def construct_output_path(inp: Path,
+                          outdir: str | Path,
+                          explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit)
+    return Path(outdir) / f"{inp.stem}{OUT_SUFFIX}{inp.suffix}"
+
+
+def dedupe_apparent_trips(df: pd.DataFrame) -> pd.DataFrame:
+    df["TripStart"] = df["Trip"].str.split().str[0]
+    sort_cols = ["Short Route", "Direction", "Timepoint ID", "TripStart"]
+    df = df.sort_values("Total Counts", ascending=False)
+    return df.drop_duplicates(subset=sort_cols, keep="first")
+
+
+def load_timepoint_order(path: str | Path | None) -> Dict[str, List[str]]:
+    if path is None:
+        return {k.upper(): v for k, v in TIMEPOINT_ORDER.items()}
+    fp = Path(path)
+    if not fp.exists():
+        sys.exit(f"ERROR: pattern-file not found – {fp}")
+    try:
+        obj = json.loads(fp.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        sys.exit(f"ERROR: invalid JSON in {fp} – {exc}")  # noqa: TRY003
+    if not isinstance(obj, dict):
+        sys.exit("ERROR: pattern-file root must be a JSON object.")
+    return {k.upper(): list(map(str, v)) for k, v in obj.items()}
+
+
+def enforce_timepoint_order(df: pd.DataFrame,
+                            order_map: Dict[str, List[str]]) -> pd.DataFrame:
+    mask = df.apply(
+        lambda row: row["Timepoint Description"]
+        in order_map.get(row["Direction"], []),
+        axis=1,
+    )
+    if not mask.all():
+        unknown = (
+            df.loc[~mask, ["Direction", "Timepoint Description"]]
+            .drop_duplicates()
+            .itertuples(index=False, name=None)
+        )
+        logging.warning(
+            "Dropped %d rows; unknown stops: %s",
+            (~mask).sum(),
+            "; ".join(f"{d} – {tp}" for d, tp in unknown),
+        )
+    return df[mask].copy()
+
+
+def pivot_route_direction(
+    df: pd.DataFrame,
+    metric: str,
+    order_map: Dict[str, List[str]],
+) -> Dict[Tuple[str, str], pd.DataFrame]:
+    """
+    Wide table for one metric.  Guarantees every configured stop exists.
+
+    Returns { (route, direction): DataFrame } with columns:
+      TripStart | Trip | <stops…>
+    """
+    results: Dict[Tuple[str, str], pd.DataFrame] = {}
+
+    for (route, direction), g in df.groupby(["Short Route", "Direction"]):
+        direction_uc = direction.upper()
+        cfg_stops = order_map.get(direction_uc, [])
+
+        if not cfg_stops:
+            logging.warning("Direction %s missing in TIMEPOINT_ORDER – skipped", direction)
+            continue
+
+        g = g.assign(
+            TPDesc=pd.Categorical(
+                g["Timepoint Description"],
+                categories=cfg_stops,
+                ordered=True,
+            ),
+            TripStart=g["Trip"].str.split().str[0],
+        )
+
+        pivot = g.pivot(index="TripStart", columns="TPDesc", values=metric)
+
+        # Merge full Trip ID
+        trip_lookup = (
+            g[["TripStart", "Trip"]]
+            .drop_duplicates(subset="TripStart")
+            .set_index("TripStart")
+        )
+        wide = trip_lookup.join(pivot)
+
+        # Ensure all configured stops appear
+        missing_cols = [s for s in cfg_stops if s not in wide.columns]
+        if missing_cols:
+            wide[missing_cols] = pd.NA
+            logging.warning(
+                "[%s %s] No OTP data for stops: %s",
+                route, direction_uc, "; ".join(missing_cols),
+            )
+
+        # Order columns
+        wide = wide[["Trip"] + cfg_stops]
+        wide = wide.sort_index()
+
+        results[(route, direction_uc)] = wide
+
+    return results
+
+
+def summary_route_direction(
+    df: pd.DataFrame,
+    order_map: Dict[str, List[str]],
+) -> Dict[Tuple[str, str], pd.DataFrame]:
+    """
+    Create a stop‑level summary for each (route, direction).
+
+    Columns
+    -------
+    Timepoint Description | AvgPct | Count
+        AvgPct : mean of % On Time (simple mean – see note below)
+        Count  : Σ Total Counts  (ontime + early + late events)
+
+    Warns once if a configured stop has zero observations.
+    """
+    summaries: Dict[Tuple[str, str], pd.DataFrame] = {}
+
+    for (route, direction), g in df.groupby(["Short Route", "Direction"]):
+        direction_uc = direction.upper()
+        cfg = order_map.get(direction_uc, [])
+
+        summ = (
+            g.groupby("Timepoint Description")
+            .agg(
+                AvgPct=("% On Time", "mean"),        # simple average
+                Count=("Total Counts", "sum"),       # ← FIXED
+            )
+            .reindex(cfg)
+        )
+
+        missing = summ[summ["Count"].isna()].index.tolist()
+        if missing:
+            logging.warning(
+                "[%s %s] No OTP data for stops: %s",
+                route, direction_uc, "; ".join(missing),
+            )
+            summ.loc[missing, ["AvgPct", "Count"]] = [pd.NA, 0]
+
+        summaries[(route, direction_uc)] = summ.reset_index()
+
+    return summaries
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+def main() -> None:
+    parser = build_argparser()
+    args, _unknown = parser.parse_known_args()
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        sys.exit(f"ERROR: input file not found – {input_path}")
+
+    df = pd.read_csv(input_path)
+    if df.empty:
+        sys.exit("ERROR: input CSV is empty.")
+
+    # config + processing ------------------------------------------------------
+    rdt_triples = parse_rdt_arg(args.rdt)
+    order_map = load_timepoint_order(args.pattern_file)
+
+    df["Short Route"] = df["Route"].astype(str).apply(make_short_route)
+    df = recalc_percentages(df)
+    df = filter_rdt(df, rdt_triples)
+    df = filter_basic(df, args.timepoints, args.routes)
+    df = dedupe_apparent_trips(df)
+    df = enforce_timepoint_order(df, order_map)
+
+    # save long table ----------------------------------------------------------
+    out_path = construct_output_path(input_path, args.outdir, args.output)
+    Path(args.outdir).mkdir(parents=True, exist_ok=True)
+    df.to_csv(out_path, index=False)
+    logging.info("Processed %d rows → %s", len(df), out_path.resolve())
+
+    # pivots & summaries -------------------------------------------------------
+    pivot_pct = pivot_route_direction(df, "% On Time", order_map)
+    pivot_cnt = pivot_route_direction(df, "Total Counts", order_map)
+    summaries = summary_route_direction(df, order_map)
+
+    outdir = Path(args.outdir)
+    for key in pivot_pct:
+        route, direction = key
+        stem = f"{route}_{direction}"
+        pivot_pct[key].reset_index().to_csv(outdir / f"{stem}_pct.csv", index=False)
+        pivot_cnt[key].reset_index().to_csv(outdir / f"{stem}_cnt.csv", index=False)
+        summaries[key].to_csv(outdir / f"{stem}_summary.csv", index=False)
+        logging.info("Wrote %s* files for %s %s", stem, route, direction)
+
+    # ------------------------------------------------------------------------
+    # TODO: integrate GTFS stop‑times and generate heatmaps or line plots
+    #       of % On Time by stop (matplotlib).  Also consider headway variance.
+    # ------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/operations_tools/otp_by_stop_pivot.py
+++ b/scripts/operations_tools/otp_by_stop_pivot.py
@@ -1,5 +1,19 @@
 """Calculate OTP percentages by stop and publish user‑friendly outputs.
 
+This script processes a raw OTP CSV export and generates user-friendly outputs
+including:
+  - Recalculated OTP percentages (% On Time, % Early, % Late)
+  - Route/direction-wide pivot tables of OTP and counts by stop
+  - Stop-level summary tables of OTP performance
+  - Optional filtering by route, direction, and timepoint
+
+It supports override of stop order using a custom JSON configuration file and
+ensures all configured stops appear in output tables, even if missing from the
+input dataset.
+
+Outputs are written to a user-specified directory, with clear filenames for each
+(route, direction) combination.
+
 TODO (future): GTFS‑synced visualizations (see stub at bottom).
 """
 

--- a/scripts/operations_tools/otp_by_stop_pivot.py
+++ b/scripts/operations_tools/otp_by_stop_pivot.py
@@ -37,7 +37,7 @@ OUTPUT_DIR: Path | str = (r"Path\To\Your\Output_Folder")
 
 OUT_SUFFIX: str = "_processed"
 
-SHORT_ROUTE_FILTER: List[str] = []
+SHORT_ROUTE_FILTER: List[str] = ["101"]
 
 TIMEPOINT_FILTER: List[str] = []
 RDT_FILTER: List[Tuple[str, str, str]] = []

--- a/scripts/operations_tools/runtime_fit_tool.py
+++ b/scripts/operations_tools/runtime_fit_tool.py
@@ -37,7 +37,7 @@ import seaborn as sns
 INPUT_ROOT_DIR: Final[Path] = Path(r"Path\To\Your\individual_trip_observations_folder")
 OUTPUT_ROOT_DIR: Final[Path] = Path(r"Path\To\Your\Output_Folder")
 
-ROUTES_TO_INCLUDE: Final[set[str]] = {"401", "402"}  # optional whitelist
+ROUTES_TO_INCLUDE: Final[set[str]] = {"101", "202"}  # optional whitelist
 
 DATE_START: Final[pd.Timestamp] = pd.Timestamp("2024-06-30")
 DATE_END: Final[pd.Timestamp] = pd.Timestamp("2025-07-24")

--- a/scripts/operations_tools/runtime_fit_tool.py
+++ b/scripts/operations_tools/runtime_fit_tool.py
@@ -1,0 +1,690 @@
+"""Trip-level runtime diagnostics and schedule performance review.
+
+This module analyzes observed bus trips to evaluate how actual runtime and timing
+deviations compare to scheduled values. It generates both row-level flags and
+summary statistics, emphasizing on-time performance (OTP) and 85th-percentile runtime.
+
+Designed to support schedule tuning, the script suggests time-of-day bands using
+Fisher–Jenks segmentation and provides visual diagnostics for start time, runtime,
+and deviation patterns.
+
+Outputs per route include:
+- CSV: Trips with deviations and OTP compliance flags
+- XLSX: Summarized runtime and OTP statistics
+- XLSX: Suggested time bands for runtime adjustment
+- PNG: Diagnostic plots (e.g., runtime boxplots, schedule vs. 85th percentile)
+
+Assumes route-wise CSVs of trip observations with key timestamp columns.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from collections import defaultdict
+from pathlib import Path
+from typing import Final, Iterable, List, Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+INPUT_ROOT_DIR: Final[Path] = Path(r"Path\To\Your\individual_trip_observations_folder")
+OUTPUT_ROOT_DIR: Final[Path] = Path(r"Path\To\Your\Output_Folder")
+
+ROUTES_TO_INCLUDE: Final[set[str]] = {"401", "402"}  # optional whitelist
+
+DATE_START: Final[pd.Timestamp] = pd.Timestamp("2024-06-30")
+DATE_END: Final[pd.Timestamp] = pd.Timestamp("2025-07-24")
+
+LOW_SAMPLE_FRAC: Final[float] = 0.20  # 20 % of the median n_events
+
+MAX_TIME_BANDS: Final[int | None] = 6  # None ⇒ no hard cap
+ENFORCE_MIN_BAND_SIZE: Final[bool] = True  # toggle merging on/off
+MIN_BAND_SIZE: Final[int] = 2  # ignored when above is False
+
+EXCLUDE_DATES: Final[list[str]] = [
+    "2025-01-01",
+    "2025-01-20",
+    "2025-02-17",
+    "2025-05-26",
+    "2025-06-19",
+    "2025-07-04",
+    "2025-09-01",
+    "2025-10-13",
+    "2025-11-11",
+    "2025-11-27",
+    "2025-11-28",
+    "2025-12-25",
+]
+
+SERVICE_DAY_FILTER: Final[str | None] = "WEEKDAY"  # "SATURDAY" | "SUNDAY" | None
+
+OTP_EARLY_MIN: Final[int] = -1
+OTP_LATE_MIN: Final[int] = 6
+OTP_TARGET_PCT: Final[float] = 85.0
+
+TIME_COL_NAME: Final[str] = "trip_start_time"
+_DOW_CHOICES: Final[set[str | None]] = {None, "", "WEEKDAY", "SATURDAY", "SUNDAY"}
+
+# Outlier‑trimming settings (per‑trip)
+TRIM_OUTLIERS: Final[bool] = True
+TRIM_FRAC: Final[float] = 0.01  # drop shortest & longest 1 %
+
+# ─── derived paths (initial stubs – reassigned per route in main()) ─── #
+OUTPUT_DIR: Path = OUTPUT_ROOT_DIR
+PLOTS_DIR: Path = OUTPUT_DIR / "plots"
+
+# =============================================================================
+# FUNCTIONS
+# =============================================================================
+
+def _detect_sep(path: Path) -> str:
+    """Return delimiter based on extension (csv → comma, others → tab)."""
+    return "," if path.suffix.lower() == ".csv" else "\t"
+
+
+def _ensure_plot_dirs() -> None:
+    PLOTS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _trim_pct(series: pd.Series, frac: float = TRIM_FRAC) -> pd.Series:
+    """Trim the lowest and highest *frac* proportion of values."""
+    if series.empty or frac <= 0:
+        return series
+    lo = series.quantile(frac)
+    hi = series.quantile(1 - frac)
+    return series[(series >= lo) & (series <= hi)]
+
+
+def _safe_plot(plot_func, df: pd.DataFrame) -> None:
+    """Only call *plot_func* when *df* is non‑empty."""
+    if not df.empty:
+        plot_func(df)
+    else:
+        print("   ⚠  No rows after filters; skipping plots.")
+
+
+# -----------------------------------------------------------------------------
+# ROUTE DISCOVERY HELPERS
+# -----------------------------------------------------------------------------
+
+_route_token_re = re.compile(r"([0-9]{1,4})")
+
+
+def _clean_route_id(raw: str | float | int) -> str:
+    """Canonical 1‑to‑4 digit route ID from a Route cell."""
+    txt = str(raw)
+    m = _route_token_re.search(txt)
+    if not m:
+        raise ValueError(f"Cannot parse route from value {txt!r}")
+    return m.group(1).lstrip("0") or "0"
+
+
+def _discover_route_csvs(
+    root: Path, wanted: set[str] | None = None
+) -> dict[str, list[Path]]:
+    """
+    Crawl *root* recursively and build {route → [files]}.
+
+    * A file is linked to **every** route ID that appears in its Route column,
+      so mixed files get processed by each relevant route run.
+    * Route column header may be “route”, “Route_ID”, “routeName”, etc.
+    * Honors *wanted* whitelist (1‑to‑4 digit IDs with leading zeros stripped).
+    """
+    buckets: dict[str, list[Path]] = defaultdict(list)
+    route_hdr_re = re.compile(r"\s*route\w*\s*", flags=re.I)
+
+    for p in root.rglob("*.csv"):
+        try:
+            # read just the header to find the Route‑like column
+            header = pd.read_csv(p, sep=_detect_sep(p), nrows=0).columns
+            route_col = next(col for col in header if route_hdr_re.fullmatch(col))
+        except StopIteration:
+            print(f"!! {p.name}: no Route column; skipped")
+            continue
+        except Exception as e:
+            print(f"!! {p.name}: {e}; skipped")
+            continue
+
+        try:
+            routes = (
+                pd.read_csv(
+                    p,
+                    sep=_detect_sep(p),
+                    usecols=[route_col],
+                    dtype=str,
+                    low_memory=False,
+                )[route_col]
+                .dropna()
+                .unique()
+            )
+            ids = {_clean_route_id(r) for r in routes}
+        except Exception as e:
+            print(f"!! {p.name}: {e}; skipped")
+            continue
+
+        if wanted:
+            ids &= wanted
+        if not ids:
+            continue  # file has no wanted routes
+
+        for rid in ids:
+            buckets[rid].append(p)
+
+    return buckets
+
+
+def load_trip_files(files: Iterable[Path]) -> pd.DataFrame:
+    frames = [
+        pd.read_csv(p, sep=_detect_sep(p), dtype=str, low_memory=False) for p in files
+    ]
+    df = pd.concat(frames, ignore_index=True)
+    for col in (
+        "Scheduled Start Time",
+        "Scheduled Finish Time",
+        "Actual Start Time",
+        "Actual Finish Time",
+    ):
+        df[col] = pd.to_datetime(df[col], errors="coerce")
+    return df
+
+
+def extract_trip_start_time(df: pd.DataFrame, trip_col: str = "Trip") -> pd.DataFrame:
+    df = df.copy()
+    df[TIME_COL_NAME] = df[trip_col].str.extract(r"^\s*([0-2]?\d:[0-5]\d)")[0]
+    return df
+
+
+def filter_date_range(df: pd.DataFrame) -> pd.DataFrame:
+    return df.loc[df["Scheduled Start Time"].between(DATE_START, DATE_END)].copy()
+
+
+def filter_routes(df: pd.DataFrame, wanted: set[str]) -> pd.DataFrame:
+    wanted_canon = {str(x).lstrip("0") for x in wanted}
+    route_num = (
+        df["Route"].astype(str).str.extract(r"^\s*([0-9]{1,4})")[0].str.lstrip("0")
+    )
+    return df.loc[route_num.isin(wanted_canon)].copy()
+
+
+def filter_holidays(df: pd.DataFrame, dates: Iterable[str]) -> pd.DataFrame:
+    bad = {pd.to_datetime(d).date() for d in dates}
+    return df.loc[~df["Scheduled Start Time"].dt.date.isin(bad)].copy()
+
+
+def filter_service_day(df: pd.DataFrame, which: str | None) -> pd.DataFrame:
+    if which not in _DOW_CHOICES:
+        raise ValueError("SERVICE_DAY_FILTER must be WEEKDAY, SATURDAY, SUNDAY or None")
+    if not which:
+        return df
+    dow = df["Scheduled Start Time"].dt.dayofweek
+    keep = (
+        (dow <= 4)
+        if which == "WEEKDAY"
+        else (dow == 5 if which == "SATURDAY" else dow == 6)
+    )
+    return df.loc[keep].copy()
+
+
+def add_deviation_cols(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    df["start_dev_min"] = (
+        df["Actual Start Time"] - df["Scheduled Start Time"]
+    ).dt.total_seconds() / 60
+    df["finish_dev_min"] = (
+        df["Actual Finish Time"] - df["Scheduled Finish Time"]
+    ).dt.total_seconds() / 60
+    df["scheduled_runtime_min"] = (
+        df["Scheduled Finish Time"] - df["Scheduled Start Time"]
+    ).dt.total_seconds() / 60
+    df["actual_runtime_min"] = (
+        df["Actual Finish Time"] - df["Actual Start Time"]
+    ).dt.total_seconds() / 60
+    df["runtime_dev_min"] = df["actual_runtime_min"] - df["scheduled_runtime_min"]
+    return df
+
+
+def add_otp_flag(df: pd.DataFrame) -> pd.DataFrame:
+    on_time = df["start_dev_min"].between(OTP_EARLY_MIN, OTP_LATE_MIN, inclusive="both")
+    return df.assign(on_time=on_time)
+
+
+def _box_by_trip(
+    df: pd.DataFrame,
+    col: str,
+    title: str,
+    file_name: str,
+    shade_range: tuple[float, float] | None = None,
+) -> None:
+    data = df[[TIME_COL_NAME, col]].dropna()
+    plt.figure(figsize=(12, 5))
+    sns.boxplot(data=data, x=TIME_COL_NAME, y=col, whis=(0, 100), showfliers=False)
+    if shade_range:
+        plt.axhspan(*shade_range, color="g", alpha=0.15)
+    plt.axhline(0, color="black", linewidth=0.8)
+    plt.title(title)
+    plt.ylabel("Minutes")
+    plt.xlabel("Scheduled trip start")
+    plt.xticks(rotation=90)
+    plt.tight_layout()
+    _ensure_plot_dirs()
+    plt.savefig(PLOTS_DIR / file_name, dpi=150)
+    plt.close()
+
+
+def plot_start_dev_shaded(df: pd.DataFrame) -> None:
+    _box_by_trip(
+        df,
+        "start_dev_min",
+        "Start‑time deviation – shaded OTP window",
+        "box_start_dev_shaded.png",
+        shade_range=(OTP_EARLY_MIN, OTP_LATE_MIN),
+    )
+
+
+def plot_start_dev_plain(df: pd.DataFrame) -> None:
+    _box_by_trip(
+        df,
+        "start_dev_min",
+        "Start‑time deviation",
+        "box_start_dev.png",
+    )
+
+
+def plot_finish_dev_shaded(df: pd.DataFrame) -> None:
+    _box_by_trip(
+        df,
+        "finish_dev_min",
+        "Finish‑time deviation – shaded OTP window",
+        "box_finish_dev_shaded.png",
+        shade_range=(OTP_EARLY_MIN, OTP_LATE_MIN),  # same thresholds for illustration
+    )
+
+
+def plot_finish_dev_plain(df: pd.DataFrame) -> None:
+    _box_by_trip(
+        df,
+        "finish_dev_min",
+        "Finish‑time deviation",
+        "box_finish_dev.png",
+    )
+
+
+def plot_runtime_dev(df: pd.DataFrame) -> None:
+    _box_by_trip(
+        df,
+        "runtime_dev_min",
+        "Runtime deviation by trip",
+        "box_runtime_dev.png",
+    )
+
+
+def _day_tag() -> str:
+    return (SERVICE_DAY_FILTER or "ALL").upper()
+
+
+def write_row_level(df: pd.DataFrame) -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    lead = ["Route", "Direction", "TripID", TIME_COL_NAME]
+    ordered = df[lead + [c for c in df.columns if c not in lead]].sort_values(
+        by=["Route", "Direction", TIME_COL_NAME, "TripID"], ignore_index=True
+    )
+    ordered.to_csv(OUTPUT_DIR / f"trips_with_deviations_{_day_tag()}.csv", index=False)
+
+
+def _sched_mode_with_warning(s: pd.Series, trip_id: str | int) -> float:
+    """Return the (possibly multi‑modal) mode of *s*, warning if ambiguous."""
+    modes = s.mode(dropna=True)
+    if modes.empty:
+        return float("nan")
+    if len(modes) > 1:
+        warnings.warn(
+            f"TripID {trip_id} has multiple scheduled runtimes "
+            f"{modes.tolist()}; using their median.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    return modes.median() if len(modes) > 1 else modes.iloc[0]
+
+
+def write_summary_table(df: pd.DataFrame) -> pd.DataFrame:
+    """Summarise each trip‑start token and return the summary DataFrame."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    trip_grp = df.groupby(TIME_COL_NAME, sort=False)
+    summary = trip_grp.agg(
+        n_events=("Actual Start Time", lambda s: s.notna().sum()),
+        otp_pct=("on_time", lambda s: s.mean() * 100.0),
+    )
+
+    summary["scheduled_runtime_mode"] = trip_grp["scheduled_runtime_min"].apply(
+        lambda s: _sched_mode_with_warning(s, trip_id=s.name)
+    )
+
+    def _runtime_stats(series: pd.Series) -> pd.Series:
+        data = _trim_pct(series) if TRIM_OUTLIERS else series
+        return pd.Series(
+            {
+                "runtime_mean_min": data.mean(),
+                "runtime_median_min": data.median(),
+                "runtime_p85_min": data.quantile(0.85),
+            }
+        )
+
+    runtime_stats = trip_grp["actual_runtime_min"].apply(_runtime_stats).unstack()
+    summary = summary.join(runtime_stats)
+    summary["under_target"] = summary["otp_pct"] < OTP_TARGET_PCT
+    summary.reset_index(drop=False, inplace=True)
+
+    summary.to_excel(
+        OUTPUT_DIR / f"trip_summary_{_day_tag()}.xlsx",
+        index=False,
+        engine="openpyxl",
+    )
+    return summary
+
+
+def log_low_sample_start_times(
+    df: pd.DataFrame,
+    thresh_frac: float = LOW_SAMPLE_FRAC,
+    *,
+    exclude_dates: Iterable[str] | None = None,
+) -> None:
+    """
+    Save a CSV listing start‑times that have *unusually few* observations.
+
+    A start‑time (e.g. “06:15”) is flagged when its row count is **below
+    `thresh_frac × median(row counts)`** across all start‑times in *df*.
+
+    The CSV (one per route) lives alongside the other artefacts and
+    contains:
+
+    * ``trip_start_time`` – HH:MM string extracted earlier
+    * ``n_obs``            – observations for that token after filtering
+    * ``dates_run``        – comma‑separated YYYY‑MM‑DD values
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The fully filtered route‑level dataframe.
+    thresh_frac : float, default ``LOW_SAMPLE_FRAC``
+        Fraction of the median observation count below which a
+        start‑time is considered under‑sampled.
+    exclude_dates : Iterable[str] | None, optional
+        Your current ``EXCLUDE_DATES`` list (YYYY‑MM‑DD strings).
+        Supplying it lets the function tell you which flagged dates are
+        *not yet* excluded.
+    """
+    # ------------------------------------------------------------------ #
+    # 1.  Observation counts per start‑time and threshold calculation.   #
+    # ------------------------------------------------------------------ #
+    counts = df.groupby(TIME_COL_NAME)["Actual Start Time"].count()
+    if counts.empty:
+        return  # no rows after earlier filters
+
+    cutoff = counts.median() * thresh_frac
+    sparse_tokens = counts[counts < cutoff]
+    if sparse_tokens.empty:
+        return  # nothing to flag
+
+    # ------------------------------------------------------------------ #
+    # 2.  Assemble diagnostic rows, including the dates run.             #
+    # ------------------------------------------------------------------ #
+    warned_df = (
+        df[df[TIME_COL_NAME].isin(sparse_tokens.index)]
+        .loc[:, [TIME_COL_NAME, "Scheduled Start Time"]]
+        .assign(
+            n_obs=lambda x: x.groupby(TIME_COL_NAME)["Scheduled Start Time"].transform(
+                "size"
+            )
+        )
+    )
+
+    out = (
+        warned_df.groupby(TIME_COL_NAME, sort=False)
+        .agg(
+            n_obs=("n_obs", "first"),
+            dates_run=(
+                "Scheduled Start Time",
+                lambda s: ", ".join(
+                    sorted({d.strftime("%Y-%m-%d") for d in s.dt.date})
+                ),
+            ),
+        )
+        .reset_index()
+    )
+
+    # ------------------------------------------------------------------ #
+    # 3.  Write the CSV and emit an actionable console message.          #
+    # ------------------------------------------------------------------ #
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    fname = OUTPUT_DIR / f"low_sample_start_times_{_day_tag()}.csv"
+    out.to_csv(fname, index=False)
+
+    print(
+        f"   ⚠  {len(out)} low‑sample start‑times logged "
+        f"(<{thresh_frac:.0%} of median obs) ➜ {fname.name}"
+    )
+
+    # If an EXCLUDE_DATES list is provided, point out any new dates.
+    if exclude_dates is not None:
+        flagged_dates: set[str] = {
+            d for dates_str in out["dates_run"] for d in dates_str.split(", ")
+        }
+        missing = flagged_dates - {str(d) for d in exclude_dates}
+        if missing:
+            print(f"      ↪ Consider adding these to EXCLUDE_DATES: {sorted(missing)}")
+
+
+def _cum_sums(arr: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    csum = np.insert(np.cumsum(arr), 0, 0.0)
+    csum_sq = np.insert(np.cumsum(arr**2), 0, 0.0)
+    return csum, csum_sq
+
+
+def _ssq(csum: np.ndarray, csum_sq: np.ndarray, i: int, j: int) -> float:
+    n = j - i
+    if n == 0:
+        return 0.0
+    s, s2 = csum[j] - csum[i], csum_sq[j] - csum_sq[i]
+    return s2 - (s * s) / n
+
+
+def _fisher_jenks(values: Sequence[float], k: int) -> List[int]:
+    arr = np.asarray(values, dtype=float)
+    n = arr.size
+    if not 2 <= k <= n:
+        raise ValueError("k must be in 2‥n")
+
+    csum, csum_sq = _cum_sums(arr)
+    dp = np.full((k, n + 1), np.inf)
+    idx = np.zeros((k, n + 1), dtype=int)
+
+    dp[0, 1:] = [_ssq(csum, csum_sq, 0, m) for m in range(1, n + 1)]
+
+    for g in range(1, k):
+        for m in range(g + 1, n + 1):
+            best, best_s = np.inf, g
+            for s in range(g, m):
+                cost = dp[g - 1, s] + _ssq(csum, csum_sq, s, m)
+                if cost < best:
+                    best, best_s = cost, s
+            dp[g, m], idx[g, m] = best, best_s
+
+    bkpts, m = [], n
+    for g in range(k - 1, 0, -1):
+        s = idx[g, m]
+        bkpts.append(s)
+        m = s
+    return sorted(bkpts)  # len == k‑1
+
+
+# -----------------------------------------------------------------------------
+#  PUBLIC API
+# -----------------------------------------------------------------------------
+def suggest_time_bands(
+    summary: pd.DataFrame,
+    *,
+    max_bands: int | None = MAX_TIME_BANDS,
+    enforce_min_size: bool = ENFORCE_MIN_BAND_SIZE,
+    min_band_size: int = MIN_BAND_SIZE,
+) -> pd.DataFrame:
+    """Return contiguous time‑of‑day bands from `runtime_p85_min`.
+
+    The DataFrame *summary* must contain ``trip_start_time`` (HH:MM str)
+    and ``runtime_p85_min``.  ``max_bands=None`` ⇒ no hard cap.
+    ``enforce_min_size=False`` skips the small‑band merge entirely.
+    """
+    need = {"trip_start_time", "runtime_p85_min"}
+    miss = need - set(summary.columns)
+    if miss:
+        raise KeyError(f"summary missing columns {miss}")
+
+    df = (
+        summary.loc[:, ["trip_start_time", "runtime_p85_min"]]
+        .dropna()
+        .assign(
+            _t=lambda x: pd.to_datetime(
+                x["trip_start_time"], format="%H:%M", errors="coerce"
+            )
+            .dt.hour.mul(60)
+            .add(pd.to_datetime(x["trip_start_time"], format="%H:%M").dt.minute)
+        )
+        .sort_values("_t", kind="mergesort")
+        .reset_index(drop=True)
+    )
+
+    n = len(df)
+    k0 = max(int(np.ceil(np.sqrt(n))), 2)
+    k = k0 if max_bands is None or max_bands <= 0 else min(k0, max_bands)
+
+    breaks = _fisher_jenks(df["runtime_p85_min"].to_numpy(), k=k)
+
+    labels = np.zeros(n, dtype=int)
+    for i, b in enumerate(breaks, start=1):
+        labels[b:] += 1
+    df["_band"] = labels
+
+    # ── optional merge of undersized bands ──────────────────────────────
+    if enforce_min_size and min_band_size > 1:
+        changed = True
+        while changed:
+            sizes = df["_band"].value_counts().sort_index()
+            small = sizes[sizes < min_band_size].index
+            if small.empty:
+                changed = False
+                continue
+            for bid in small:
+                idx = sizes.index.get_loc(bid)
+                opts = []
+                if idx > 0:
+                    left = sizes.index[idx - 1]
+                    diff = abs(
+                        df.loc[df["_band"] == bid, "runtime_p85_min"].mean()
+                        - df.loc[df["_band"] == left, "runtime_p85_min"].mean()
+                    )
+                    opts.append((left, diff))
+                if idx < len(sizes) - 1:
+                    right = sizes.index[idx + 1]
+                    diff = abs(
+                        df.loc[df["_band"] == bid, "runtime_p85_min"].mean()
+                        - df.loc[df["_band"] == right, "runtime_p85_min"].mean()
+                    )
+                    opts.append((right, diff))
+                merge_into = min(opts, key=lambda t: t[1])[0]
+                df.loc[df["_band"] == bid, "_band"] = merge_into
+            remap = {old: new for new, old in enumerate(sorted(df["_band"].unique()))}
+            df["_band"] = df["_band"].map(remap)
+
+    bands = (
+        df.groupby("_band", sort=True, observed=True)
+        .agg(
+            start_time=("trip_start_time", "first"),
+            end_time=("trip_start_time", "last"),
+            n_tokens=("trip_start_time", "size"),
+            p85_mean_min=("runtime_p85_min", "mean"),
+        )
+        .reset_index(names="band_id")
+        .assign(band_id=lambda x: x["band_id"] + 1)
+    )
+    return bands
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+def main() -> None:  # pragma: no cover
+    """Process each route folder, export row‑level, summary, and band tables."""
+    whitelist = (
+        {r.lstrip("0") for r in ROUTES_TO_INCLUDE} if ROUTES_TO_INCLUDE else None
+    )
+    print(f"→ Crawling {INPUT_ROOT_DIR} for CSVs …")
+    route_files = _discover_route_csvs(INPUT_ROOT_DIR, whitelist)
+    if not route_files:
+        raise FileNotFoundError("No CSV files found under the supplied folder.")
+
+    for route, paths in sorted(route_files.items()):
+        print(f"— Processing route {route} ({len(paths)} files) …")
+
+        df = (
+            load_trip_files(paths)
+            .pipe(extract_trip_start_time)
+            .pipe(filter_date_range)
+            .pipe(filter_routes, {route})
+            .pipe(filter_holidays, EXCLUDE_DATES)
+            .pipe(filter_service_day, SERVICE_DAY_FILTER)
+            .pipe(add_deviation_cols)
+            .pipe(add_otp_flag)
+        )
+
+        if df.empty:
+            print("   ⚠  No rows left after filtering; skipping route.")
+            continue
+
+        global OUTPUT_DIR, PLOTS_DIR
+        OUTPUT_DIR = OUTPUT_ROOT_DIR / route
+        PLOTS_DIR = OUTPUT_DIR / "plots"
+
+        write_row_level(df)
+        summary = write_summary_table(df)  # ← returns DataFrame
+        bands = suggest_time_bands(summary)  # ← generate time‑bands
+        bands.to_excel(
+            OUTPUT_DIR / f"time_bands_{_day_tag()}.xlsx",
+            index=False,
+            engine="openpyxl",
+        )
+        print(f"   → Suggested {len(bands)} time bands saved.")
+
+        # ── plotting (skip gracefully if a function is missing) ──
+        plot_funcs = [
+            "plot_start_dev_shaded",
+            "plot_start_dev_plain",
+            "plot_finish_dev_shaded",
+            "plot_finish_dev_plain",
+            "plot_runtime_dev",
+            "plot_obs_counts",
+            "plot_start_time_categories",
+            "plot_runtime_p85_vs_sched",
+            "plot_runtime_deviation_scatter",
+        ]
+        for name in plot_funcs:
+            func = globals().get(name)
+            if callable(func):
+                _safe_plot(func, df)
+            else:
+                print(f"   ⚠  Skipping {name}: not defined in this session.")
+
+        print(f"✓ Finished route {route}")
+
+    print("✓✓ All routes processed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/operations_tools/runtime_fit_tool.py
+++ b/scripts/operations_tools/runtime_fit_tool.py
@@ -23,7 +23,7 @@ import re
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import Final, Iterable, List, Sequence
+from typing import Final, Iterable, List, Sequence, Callable
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -80,6 +80,12 @@ TRIM_FRAC: Final[float] = 0.01  # drop shortest & longest 1 %
 OUTPUT_DIR: Path = OUTPUT_ROOT_DIR
 PLOTS_DIR: Path = OUTPUT_DIR / "plots"
 
+# ---------------------------------------------------------------------
+# TYPE ALIASES
+# ---------------------------------------------------------------------
+
+PlotFunc: TypeAlias = Callable[[pd.DataFrame], None]
+
 # =============================================================================
 # FUNCTIONS
 # =============================================================================
@@ -102,7 +108,7 @@ def _trim_pct(series: pd.Series, frac: float = TRIM_FRAC) -> pd.Series:
     return series[(series >= lo) & (series <= hi)]
 
 
-def _safe_plot(plot_func, df: pd.DataFrame) -> None:
+def _safe_plot(plot_func: PlotFunc, df: pd.DataFrame) -> None:
     """Safely call a plotting function if the DataFrame is not empty.
 
     Args:
@@ -367,6 +373,12 @@ def plot_start_dev_shaded(df: pd.DataFrame) -> None:
 
 
 def plot_start_dev_plain(df: pd.DataFrame) -> None:
+    """Box‑plot start‑time deviation without OTP shading.
+
+    Args:
+        df: Fully filtered trip‑level data containing
+            ``'start_dev_min'`` and ``'trip_start_time'`` columns.
+    """
     _box_by_trip(
         df,
         "start_dev_min",
@@ -376,6 +388,11 @@ def plot_start_dev_plain(df: pd.DataFrame) -> None:
 
 
 def plot_finish_dev_shaded(df: pd.DataFrame) -> None:
+    """Box‑plot finish‑time deviation with the OTP window shaded.
+
+    Args:
+        df: Trip‑level DataFrame with ``'finish_dev_min'`` present.
+    """
     _box_by_trip(
         df,
         "finish_dev_min",
@@ -386,6 +403,11 @@ def plot_finish_dev_shaded(df: pd.DataFrame) -> None:
 
 
 def plot_finish_dev_plain(df: pd.DataFrame) -> None:
+    """Box‑plot finish‑time deviation without shading.
+
+    Args:
+        df: Trip‑level DataFrame with ``'finish_dev_min'`` present.
+    """
     _box_by_trip(
         df,
         "finish_dev_min",
@@ -395,6 +417,11 @@ def plot_finish_dev_plain(df: pd.DataFrame) -> None:
 
 
 def plot_runtime_dev(df: pd.DataFrame) -> None:
+    """Box‑plot runtime deviation (actual – scheduled) by trip.
+
+    Args:
+        df: Trip‑level DataFrame with ``'runtime_dev_min'`` present.
+    """
     _box_by_trip(
         df,
         "runtime_dev_min",

--- a/scripts/operations_tools/runtime_fit_tool.py
+++ b/scripts/operations_tools/runtime_fit_tool.py
@@ -23,7 +23,7 @@ import re
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import Final, Iterable, List, Sequence, Callable
+from typing import Final, Iterable, List, Sequence, Callable, TypeAlias
 
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
This commit introduces two initial scripts for analyzing and reporting on bus service performance based on observed trip data and OTP timepoint exports:

1. Stop-Level OTP Summary Script
   - Ingests a raw OTP-by-timepoint CSV export and recalculates % On Time, % Early, and % Late.
   - Produces:
     - Pivot tables (% On Time and counts) by stop for each (route, direction).
     - Summary tables aggregating OTP by stop.
     - Optional filtering by route, direction, and/or timepoint ID.
   - Supports a custom JSON file for enforcing stop order and ensures full stop inclusion in outputs.
   - Lays groundwork for future GTFS-synced visualizations.

2. Trip-Level Runtime and Deviation Diagnostics
   - Analyzes individual trip observations (from CSVs) against schedule, computing:
     - Start/finish deviation, runtime delta, OTP flags.
     - 85th-percentile runtime and low-sample warnings.
     - Suggested time bands using Fisher–Jenks segmentation.
   - Outputs:
     - Row-level CSV with flags.
     - Summary XLSX of runtimes and OTP by time.
     - Time band XLSX table.
     - PNG plots (e.g., runtime deviations, OTP scatter, P85 vs. scheduled).
   - Supports filtering by date range, weekday/weekend/holiday exclusion, and route ID.

Both scripts are structured for CLI use and configured with top-level constants for customization. Logging and argument parsing are implemented for clarity and reproducibility.

This PR establishes a foundation for more advanced schedule tuning and reliability diagnostics using observed performance data.
