### PR TITLE
feat(maps): Show network centerlines, labels, and feet-based titles

### DIFF
--- a/.github/workflows/committed_check.yml
+++ b/.github/workflows/committed_check.yml
@@ -25,4 +25,4 @@ jobs:
           fetch-depth: 0  # Required so Committed can see all commits in the PR
 
       - name: Run Committed
-        uses: astral-sh/committed-action@v1
+        uses: crate-ci/committed@v1.1.7


### PR DESCRIPTION
Enhance export_stop_maps to improve clarity and user-friendliness.

- Plot the actual network centerlines (segments) used for analysis, in addition to any optional backdrop.
- Annotate removed and kept stops with stop_name alongside stop_id for better readability.
- Display network distances in feet in map titles, converting from miles and handling sentinel values (> 0.25 → > 1,320 ft).
- Improve point labeling with small offsets to avoid overlap.
- Move matplotlib import to the module level for clarity and consistency.
- Remove unnecessary noqa suppression for ANN001 and add full type hints to export_stop_maps.

Also update main() to pass the segments GeoDataFrame into export_stop_maps.