### PR TITLE
ci: Rename workflow files and remove Ruff/Ty from tests.yml

### DIFF
--- a/.github/workflows/format-lint-autofix-weekly.yml
+++ b/.github/workflows/format-lint-autofix-weekly.yml
@@ -1,5 +1,5 @@
-# .github/workflows/ruff_ty_weekly.yml
-name: ruff_ty_weekly
+# .github/workflows/format-lint-autofix-weekly.yml
+name: format-lint-autofix-weekly
 
 on:
   schedule:

--- a/.github/workflows/format-lint-typecheck.yml
+++ b/.github/workflows/format-lint-typecheck.yml
@@ -1,5 +1,5 @@
-# .github/workflows/ruff_ty_check.yml
-name: ruff_ty_check
+# .github/workflows/format-lint-typecheck.yml
+name: format-lint-typecheck
 
 on:
   # Run only on PRs that target `main` (and when manually triggered)

--- a/.github/workflows/helper-audit.yml
+++ b/.github/workflows/helper-audit.yml
@@ -1,4 +1,4 @@
-# .github/workflows/helper_audit.yml
+# .github/workflows/helper-audit.yml
 name: helper-audit
 
 on:

--- a/.github/workflows/helper-audit.yml
+++ b/.github/workflows/helper-audit.yml
@@ -1,5 +1,5 @@
 # .github/workflows/helper_audit.yml
-name: helper_audit
+name: helper-audit
 
 on:
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: tests
 
 on:
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,4 @@
+# .github/workflows/tests.yml
 name: tests
 
 on:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,14 +24,7 @@ jobs:
       - name: Install tooling
         run: |
           python -m pip install -U pip
-          pip install pytest pytest-cov ruff pandas
-
-      - name: Format check (show diff if failing)
-        run: |
-          ruff format --check . || { echo "Formatter diff:"; ruff format --diff .; exit 1; }
-
-      - name: Lint
-        run: ruff check --output-format=github .
+          pip install pytest pytest-cov pandas
 
       - name: Run tests with coverage
         env:


### PR DESCRIPTION
### Summary
Renamed CI workflow files for consistency and separated responsibilities more cleanly.
Removed Ruff and Ty steps from `tests.yml` so it focuses exclusively on running pytest.

### Changes
- Renamed workflow files:
  - `CI.yml` → `tests.yml`
  - `ruff_ty_check.yml` → `format-lint-typecheck.yml`
  - `ruff_ty_weekly.yml` → `format-lint-autofix-weekly.yml`
  - `helper_audit.yml` → `helper-audit.yml`
- Removed Ruff and Ty installation and checks from `tests.yml`.
- Added concurrency and clarified triggers for each workflow.
- Updated references in path filters and documentation as needed.

### Rationale
Improves workflow clarity, isolates test runs from style checks, and aligns filenames with GitHub convention (kebab-case).

### Impact
- No functional code changes.
- CI and PR checks remain equivalent in coverage but cleaner and faster.
- Developers run tests only once per PR instead of multiple redundant invocations.