### PR TITLE
feat(gtfs-checklists): Rewrite generator and add nearby-stop QA

### DIFF
--- a/scripts/field_tools/ridecheck_cluster_checklists.py
+++ b/scripts/field_tools/ridecheck_cluster_checklists.py
@@ -1,25 +1,42 @@
-"""Generates printable Excel checklists of GTFS stop times by custom stop clusters and schedule types.
+"""Generate Excel field-audit checklists from a GTFS feed.
 
-The script is intended for field auditing and service verification. It:
-    1. Validates the presence of required GTFS text files.
-    2. Loads the data into `pandas` DataFrames.
-    3. Optionally swaps `stop_id` for `stop_code` so downstream logic is agnostic.
-    4. Slices trips by calendar service days and user-defined clusters.
-    5. Writes one Excel workbook per *cluster × schedule × time-window* to
-       `BASE_OUTPUT_PATH`, pre-formatted with placeholders for actual arrival /
-       departure times, bus numbers, and comments.
+This module produces printable checklists for on-street audits by slicing GTFS
+stop-times data by schedule type (e.g., weekday) and user-defined stop clusters
+(e.g., station complexes). Each (cluster × schedule × time-window) combination
+is exported as a formatted Excel workbook with placeholders for observed times,
+bus numbers, and comments.
 
-Typical Usage
-- ArcGIS Pro Python window
-- Jupyter Notebook
-- Plain command line
+Workflow:
+    1. Validate presence of required GTFS text files.
+    2. Load trips, stop_times, routes, stops, and calendar.
+    3. Resolve cluster definitions to canonical ``stop_id`` values
+       (optionally via ``stop_code``).
+    4. Optionally flag non-cluster stops within a configured distance of any
+       cluster stop.
+    5. For each schedule type:
+         a. Select active service_ids based on calendar day flags.
+         b. Build a joined table (stop_times → trips → routes → stops).
+         c. Extract rows for each cluster and normalize times.
+         d. Insert auditing placeholders and export Excel outputs.
 
 Outputs:
-    - One Excel file per cluster × schedule × time window to BASE_OUTPUT_PATH
+    * One full-day workbook per (cluster × schedule).
+    * Optional time-window-specific workbooks.
+    * Optional CSV report of nearby non-cluster stops.
+
+Assumptions:
+    * GTFS feed is internally consistent.
+    * Calendar columns are 0/1 flags.
+    * Clusters are defined in this configuration block using either ``stop_id``
+      or ``stop_code``.
 """
 
+from __future__ import annotations
+
+import math
 import os
-from typing import Dict, List, Optional, Tuple
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import pandas as pd
 from openpyxl.styles import Alignment, Font
@@ -29,356 +46,552 @@ from openpyxl.utils import get_column_letter
 # CONFIGURATION
 # =============================================================================
 
-# Output directory
-BASE_OUTPUT_PATH = r"\\your_file_path\here\\"
+# Output directory for generated Excel checklists and nearby-stop QA reports.
+# Use a local or network path that field staff can access.
+BASE_OUTPUT_PATH = r"R:\transit\field_checks\YYYY_MM_checklists"
 
-# Input file paths to load GTFS files with specified dtypes
-BASE_INPUT_PATH = r"\\your_file_path\here\\"
+# Input directory containing a complete GTFS feed (trips.txt, stop_times.txt,
+# routes.txt, stops.txt, calendar.txt).
+BASE_INPUT_PATH = r"R:\transit\gtfs\connector_YYYY_MM_DD"
 
-# Which field to use for clustering filters, 'stop_id' or 'stop_code'
-STOP_IDENTIFIER_FIELD = "stop_code"  # or 'stop_id'
+# How CLUSTERS are specified:
+# - "stop_id"  -> CLUSTERS lists are stop_id values from stops.txt
+# - "stop_code" -> CLUSTERS lists are stop_code values; we map them to stop_id.
+STOP_IDENTIFIER_FIELD = "stop_code"  # or "stop_id"
 
-# Define columns to read as strings
-DTYPE_DICT = {
+# Columns to force as strings (others infer automatically)
+DTYPE_DICT: Dict[str, type] = {
     "stop_id": str,
     "trip_id": str,
     "route_id": str,
     "service_id": str,
-    # Add other ID fields as needed
+    "stop_code": str,
 }
 
-# List of required GTFS files
-GTFS_FILES = ["trips.txt", "stop_times.txt", "routes.txt", "stops.txt", "calendar.txt"]
+# Required GTFS files
+GTFS_FILES: List[str] = [
+    "trips.txt",
+    "stop_times.txt",
+    "routes.txt",
+    "stops.txt",
+    "calendar.txt",
+]
 
-# Define clusters with stop IDs or stop_codes (depending on STOP_IDENTIFIER_FIELD)
-# Format: {'Cluster Name': ['identifier1', 'identifier2', ...]}
-CLUSTERS = {
-    "Your Cluster 1": ["1", "2", "3"],  # If using 'stop_id', these are stop_ids
-    "Your Cluster 2": ["4", "5", "6"],  # If using 'stop_code', these must be stop_codes
-    "Your Cluster 3": ["7", "8", "9", "10"],
+# Clusters keyed on STOP_IDENTIFIER_FIELD.
+# If STOP_IDENTIFIER_FIELD == "stop_id", these must be stop_id values.
+# If STOP_IDENTIFIER_FIELD == "stop_code", these must be stop_code values.
+CLUSTERS: Dict[str, List[str]] = {
+    "Sample Transit Center": [
+        "1001",
+        "1002",
+        "1003",
+    ],
+    "Sample Park & Ride": [
+        "2001",
+        "2002",
+    ],
+    # "Another Hub": ["3001", "3002", "3003"],
 }
 
-# Define schedule types and corresponding days in the calendar
-# Format: {'Schedule Type': ['day1', 'day2', ...]}
-SCHEDULE_TYPES = {
+# Schedule types and which calendar columns must be 1/True
+SCHEDULE_TYPES: Dict[str, List[str]] = {
     "Weekday": ["monday", "tuesday", "wednesday", "thursday", "friday"],
-    "Saturday": ["saturday"],
-    "Sunday": ["sunday"],
-    # 'Friday': ['friday'],  # Uncomment if you have a unique Friday schedule
+    # "Saturday": ["saturday"],
+    # "Sunday": ["sunday"],
 }
 
-# Time windows for filtering trips
-# Format: {'Schedule Type': {'Time Window Name': ('Start Time', 'End Time')}}
-# Times should be in 'HH:MM' 24-hour format
-TIME_WINDOWS = {
+# Time windows per schedule type
+TIME_WINDOWS: Dict[str, Dict[str, Tuple[str, str]]] = {
     "Weekday": {
         "morning": ("06:00", "09:59"),
         "afternoon": ("14:00", "17:59"),
-        # 'evening': ('18:00', '21:59'),  # Add as needed
     },
-    "Saturday": {
-        "midday": ("10:00", "13:59"),
-        # Add more time windows for Saturday if needed
-    },
-    # 'Sunday': {  # Uncomment and customize for Sunday if needed
-    #     'morning': ('08:00', '11:59'),
-    #     'afternoon': ('12:00', '15:59'),
-    # },
+    # "Saturday": { ... },
+    # "Sunday": { ... },
 }
 
-# Optional: List of route_short_name strings to be bolded in the Excel output.
-# Ensure these are strings, matching the type in your routes.txt -> route_short_name.
-SPECIAL_ROUTES = [
-    str(x) for x in (101, 202, 303, 404, 505, 606, 707)
-]  # Example list, customize as needed
+# Route_short_name values to bold in the Excel output
+SPECIAL_ROUTES: List[str] = [
+    # "101",
+    # "202",
+]
+
+# Nearby-stop QA buffer
+NEARBY_STOP_BUFFER_FT: int = 500
+
+# Internal constants
+_FEET_TO_METERS = 0.3048
+_EARTH_RADIUS_M = 6_371_000.0
 
 # =============================================================================
-# FUNCTIONS
+# FILE / IO HELPERS
 # =============================================================================
 
+def validate_input_directory(base_input_path: str, gtfs_files: Iterable[str]) -> None:
+    """Ensure base_input_path exists and contains all GTFS_FILES."""
+    if not os.path.isdir(base_input_path):
+        raise FileNotFoundError(f"Input directory does not exist: {base_input_path}")
 
-def validate_input_directory(base_input_path: str, gtfs_files: List[str]) -> None:
-    """Verify that *all* required GTFS files exist in the given directory.
-
-    Args:
-        base_input_path: Absolute or relative path that should contain the
-            GTFS text files.
-        gtfs_files: File names that **must** be found in
-            ``base_input_path`` (e.g. ``["trips.txt", ...]``).
-
-    Raises:
-        FileNotFoundError: If the directory itself or any file in
-            ``gtfs_files`` is missing.
-    """
-    if not os.path.exists(base_input_path):
-        raise FileNotFoundError(f"The input directory {base_input_path} does not exist.")
-
+    missing: List[str] = []
     for file_name in gtfs_files:
-        file_path = os.path.join(base_input_path, file_name)
-        if not os.path.exists(file_path):
-            raise FileNotFoundError(
-                f"The required GTFS file {file_name} does not exist in {base_input_path}."
-            )
+        path = os.path.join(base_input_path, file_name)
+        if not os.path.isfile(path):
+            missing.append(file_name)
+
+    if missing:
+        raise FileNotFoundError(
+            f"Missing required GTFS file(s) in {base_input_path}: {', '.join(missing)}"
+        )
 
 
 def create_output_directory(base_output_path: str) -> None:
-    """Create ``base_output_path`` if it does not already exist.
-
-    Args:
-        base_output_path: Folder into which Excel files will be written.
-
-    Notes:
-        *The function is idempotent*: calling it repeatedly is safe.
-    """
-    if not os.path.exists(base_output_path):
-        os.makedirs(base_output_path)
+    """Create base_output_path if needed (idempotent)."""
+    os.makedirs(base_output_path, exist_ok=True)
 
 
 def load_gtfs_data(
     base_input_path: str, dtype_dict: Dict[str, type]
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    """Read required GTFS tables into memory.
-
-    Args:
-        base_input_path: Directory containing the GTFS text files.
-        dtype_dict: Mapping of column names to dtypes passed to
-            :pymeth:`pandas.read_csv`.
-
-    Returns:
-        A 5-tuple of DataFrames in the order
-        ``(trips, stop_times, routes, stops, calendar)``.
-
-    Raises:
-        FileNotFoundError: If any of the required files are not present.
-        pandas.errors.ParserError: If a file cannot be parsed as CSV.
-    """
+    """Load trips, stop_times, routes, stops, calendar from a GTFS folder."""
     trips = pd.read_csv(os.path.join(base_input_path, "trips.txt"), dtype=dtype_dict)
-    stop_times = pd.read_csv(os.path.join(base_input_path, "stop_times.txt"), dtype=dtype_dict)
+    stop_times = pd.read_csv(
+        os.path.join(base_input_path, "stop_times.txt"), dtype=dtype_dict
+    )
     routes = pd.read_csv(os.path.join(base_input_path, "routes.txt"), dtype=dtype_dict)
     stops = pd.read_csv(os.path.join(base_input_path, "stops.txt"), dtype=dtype_dict)
-    calendar = pd.read_csv(os.path.join(base_input_path, "calendar.txt"), dtype=dtype_dict)
+    calendar = pd.read_csv(
+        os.path.join(base_input_path, "calendar.txt"), dtype=dtype_dict
+    )
     return trips, stop_times, routes, stops, calendar
 
 
-def apply_stop_identifier_mode(stops_df: pd.DataFrame, stop_identifier_field: str) -> None:
-    """Align `stops_df` so downstream code can always key on ``stop_id``.
+# =============================================================================
+# IDENTIFIER / CLUSTER RESOLUTION
+# =============================================================================
 
-    If the user elects to use ``stop_code`` as the primary identifier, this
-    function overwrites (or creates) the ``stop_id`` column with the contents
-    of ``stop_code``.
-
-    Args:
-        stops_df: The *stops.txt* table.
-        stop_identifier_field: Either ``"stop_id"`` or ``"stop_code"``.
-
-    Raises:
-        ValueError: If ``stop_identifier_field`` is not one of the two allowed
-            values **or** ``stop_code`` is missing when requested.
-    """
-    if stop_identifier_field not in ["stop_id", "stop_code"]:
-        raise ValueError("STOP_IDENTIFIER_FIELD must be 'stop_id' or 'stop_code'.")
-
-    if stop_identifier_field == "stop_code":
-        if "stop_code" not in stops_df.columns:
-            raise ValueError("No 'stop_code' column found in stops data.")
-        # Overwrite stops['stop_id'] with the values from stop_code
-        stops_df["stop_id"] = stops_df["stop_code"]
+def _normalize_identifier_list(values: Iterable[str | int]) -> List[str]:
+    """Return a list of str identifiers from a heterogeneous list."""
+    return [str(v) for v in values]
 
 
-def fix_time_format(time_str: str) -> str:
-    """Normalize GTFS HH:MM[:SS] strings to *24-hour* ``"HH:MM"``.
+def build_cluster_stop_ids(
+    stops: pd.DataFrame,
+    clusters: Dict[str, List[str]],
+    identifier_field: str,
+) -> Dict[str, List[str]]:
+    """Resolve cluster definitions to canonical stop_id lists.
 
-    The GTFS spec permits hours ≥ 24 for post-midnight trips; values in that
-    range are wrapped back into 0–23.
+    Clusters may be keyed on stop_id or stop_code, but this function always returns
+    a mapping of cluster_name -> list of stop_id strings that exist in `stops`.
 
     Args:
-        time_str: A time string such as ``"27:15:00"`` or ``"05:07"``.
+        stops: GTFS stops table with at least stop_id and optionally stop_code.
+        clusters: Mapping of cluster_name -> identifiers (stop_id or stop_code).
+        identifier_field: "stop_id" or "stop_code".
 
     Returns:
-        The same instant expressed as ``"HH:MM"`` (two-digit padding).
+        Dictionary mapping cluster_name -> list of canonical stop_id values (as str).
 
     Raises:
-        ValueError: If ``time_str`` is not parseable as ``H+:MM[:SS]``.
+        ValueError: If identifier_field is invalid or critical columns are missing.
     """
-    parts = time_str.split(":")
-    hours = int(parts[0])
-    minutes = int(parts[1])
-    if hours >= 24:
-        hours -= 24
-    return f"{hours:02}:{minutes:02}"
+    if identifier_field not in {"stop_id", "stop_code"}:
+        raise ValueError("identifier_field must be 'stop_id' or 'stop_code'.")
+
+    if "stop_id" not in stops.columns:
+        raise ValueError("stops dataframe must contain 'stop_id' column.")
+
+    stops_local = stops.copy()
+    stops_local["stop_id"] = stops_local["stop_id"].astype(str)
+
+    if identifier_field == "stop_id":
+        # Simple case: cluster identifiers are stop_id.
+        cluster_to_ids: Dict[str, List[str]] = {}
+        existing_stop_ids: Set[str] = set(stops_local["stop_id"].astype(str))
+
+        for cname, ids in clusters.items():
+            id_list = _normalize_identifier_list(ids)
+            matched = [sid for sid in id_list if sid in existing_stop_ids]
+            missing = [sid for sid in id_list if sid not in existing_stop_ids]
+            if missing:
+                print(
+                    f"Warning: cluster '{cname}' references stop_id(s) not found in "
+                    f"stops.txt: {missing}"
+                )
+            if not matched:
+                print(
+                    f"Warning: cluster '{cname}' has no valid stop_ids after "
+                    "resolution; it will be skipped."
+                )
+            cluster_to_ids[cname] = matched
+
+        return cluster_to_ids
+
+    # identifier_field == "stop_code"
+    if "stop_code" not in stops_local.columns:
+        raise ValueError(
+            "identifier_field is 'stop_code' but stops.txt has no 'stop_code' column."
+        )
+
+    stops_local["stop_code"] = stops_local["stop_code"].astype(str)
+
+    # Map stop_code -> list of stop_id (in case of duplicates)
+    code_to_ids: Dict[str, List[str]] = {}
+    for _, row in stops_local[["stop_code", "stop_id"]].dropna().iterrows():
+        code = row["stop_code"]
+        sid = row["stop_id"]
+        code_to_ids.setdefault(code, []).append(sid)
+
+    cluster_to_ids = {}
+    for cname, codes in clusters.items():
+        codes_str = _normalize_identifier_list(codes)
+        resolved_ids: List[str] = []
+        for code in codes_str:
+            if code not in code_to_ids:
+                print(
+                    f"Warning: cluster '{cname}' references stop_code '{code}' not "
+                    "found in stops.txt."
+                )
+                continue
+            mapped_ids = sorted(set(code_to_ids[code]))
+            if len(mapped_ids) > 1:
+                print(
+                    f"Warning: stop_code '{code}' for cluster '{cname}' maps to "
+                    f"multiple stop_ids {mapped_ids}; all will be included."
+                )
+            resolved_ids.extend(mapped_ids)
+
+        resolved_ids = sorted(set(resolved_ids))
+        if not resolved_ids:
+            print(
+                f"Warning: cluster '{cname}' has no valid stop_ids after resolving "
+                "stop_code; it will be skipped."
+            )
+        cluster_to_ids[cname] = resolved_ids
+
+    return cluster_to_ids
 
 
-def export_to_excel(df: pd.DataFrame, output_file: str) -> None:
-    """Write a DataFrame to a formatted Excel workbook.
+# =============================================================================
+# TIME HELPERS
+# =============================================================================
 
-    Formatting rules
-    ----------------
-    * Header row left-aligned.
-    * Entire row **bold** where ``route_short_name`` is in
-      :pydata:`SPECIAL_ROUTES`.
-    * Column widths auto-sized based on max cell length.
+def normalize_gtfs_time_to_hhmm(time_str: str) -> str:
+    """Normalize GTFS HH:MM[:SS] (possibly ≥ 24h) to 'HH:MM' 0–23h.
 
     Args:
-        df: Data to export.
-        output_file: Full path of the ``*.xlsx`` file to create.
+        time_str: GTFS time string (e.g. '27:15:00', '05:07', '06:30:30').
+
+    Returns:
+        Time represented as 'HH:MM' with hours modulo 24.
 
     Raises:
-        PermissionError: If the target file is open or write-protected.
+        ValueError: If time_str is not parseable.
     """
+    if pd.isna(time_str):
+        raise ValueError("Cannot normalize NaN time string.")
+
+    parts = str(time_str).split(":")
+    if len(parts) < 2:
+        raise ValueError(f"Invalid time string: {time_str!r}")
+
+    hours = int(parts[0])
+    minutes = int(parts[1])
+
+    hours = hours % 24
+    return f"{hours:02d}:{minutes:02d}"
+
+
+# =============================================================================
+# NEARBY STOP QA
+# =============================================================================
+
+
+def _haversine_m(
+    lat1: float,
+    lon1: float,
+    lat2: pd.Series,
+    lon2: pd.Series,
+) -> pd.Series:
+    """Vectorized haversine distance from one point to many points (meters)."""
+    lat1r = math.radians(lat1)
+    lon1r = math.radians(lon1)
+
+    lat2r = lat2.astype(float).map(math.radians)
+    lon2r = lon2.astype(float).map(math.radians)
+
+    dlat = lat2r - lat1r
+    dlon = lon2r - lon1r
+
+    a = (dlat / 2.0).map(math.sin) ** 2 + math.cos(lat1r) * (
+        lat2r.map(math.cos)
+    ) * ((dlon / 2.0).map(math.sin) ** 2)
+
+    c = 2 * a.map(math.sqrt).map(lambda x: math.asin(min(1.0, x)))
+    return _EARTH_RADIUS_M * c
+
+
+def find_nearby_stops_for_clusters(
+    stops: pd.DataFrame,
+    cluster_stop_ids: Dict[str, List[str]],
+    buffer_ft: int,
+    verbose: bool = True,
+) -> pd.DataFrame:
+    """Find stops within buffer_ft of any cluster stop but not in that cluster.
+
+    Args:
+        stops: GTFS stops table with at least stop_id, stop_name, stop_lat, stop_lon.
+        cluster_stop_ids: Mapping of cluster_name -> list of stop_id (canonical).
+        buffer_ft: Distance threshold in feet.
+        verbose: Whether to print summary warnings.
+
+    Returns:
+        DataFrame with columns:
+            ['cluster', 'anchor_stop_id', 'anchor_stop_name',
+             'nearby_stop_id', 'nearby_stop_name', 'distance_ft']
+    """
+    required = {"stop_id", "stop_name", "stop_lat", "stop_lon"}
+    missing = required.difference(stops.columns)
+    if missing:
+        raise ValueError(f"stops is missing columns: {sorted(missing)}")
+
+    stops_local = stops.copy()
+    stops_local["stop_id"] = stops_local["stop_id"].astype(str)
+
+    buffer_m = buffer_ft * _FEET_TO_METERS
+    records: List[Dict[str, object]] = []
+
+    for cname, id_list in cluster_stop_ids.items():
+        if not id_list:
+            if verbose:
+                print(f"Skipping nearby-stop QA for cluster '{cname}' (no stop_ids).")
+            continue
+
+        anchor_ids: Set[str] = set(id_list)
+        anchors = stops_local[stops_local["stop_id"].isin(anchor_ids)]
+        others = stops_local[~stops_local["stop_id"].isin(anchor_ids)]
+
+        if anchors.empty:
+            if verbose:
+                print(
+                    f"Warning: no anchor stops found for cluster '{cname}' in stops.txt."
+                )
+            continue
+
+        for _, arow in anchors.iterrows():
+            dists_m = _haversine_m(
+                float(arow["stop_lat"]),
+                float(arow["stop_lon"]),
+                others["stop_lat"],
+                others["stop_lon"],
+            )
+            mask = dists_m <= buffer_m
+            if not mask.any():
+                continue
+
+            near = others.loc[mask, ["stop_id", "stop_name"]].copy()
+            near["distance_ft"] = (dists_m.loc[mask] / _FEET_TO_METERS).round(1)
+
+            for _, nrow in near.iterrows():
+                records.append(
+                    {
+                        "cluster": cname,
+                        "anchor_stop_id": arow["stop_id"],
+                        "anchor_stop_name": arow["stop_name"],
+                        "nearby_stop_id": nrow["stop_id"],
+                        "nearby_stop_name": nrow["stop_name"],
+                        "distance_ft": float(nrow["distance_ft"]),
+                    }
+                )
+
+        if verbose:
+            cnt = sum(1 for r in records if r["cluster"] == cname)
+            if cnt > 0:
+                print(
+                    f"Warning: cluster '{cname}' has {cnt} nearby stop(s) within "
+                    f"{buffer_ft} ft that are not in the cluster."
+                )
+
+    result = pd.DataFrame.from_records(
+        records,
+        columns=[
+            "cluster",
+            "anchor_stop_id",
+            "anchor_stop_name",
+            "nearby_stop_id",
+            "nearby_stop_name",
+            "distance_ft",
+        ],
+    )
+
+    if verbose and not result.empty and os.path.isdir(BASE_OUTPUT_PATH):
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        out_csv = os.path.join(BASE_OUTPUT_PATH, f"nearby_stop_warnings_{ts}.csv")
+        try:
+            result.sort_values(
+                ["cluster", "anchor_stop_id", "distance_ft"]
+            ).to_csv(out_csv, index=False)
+            print(f"Nearby stop report written to {out_csv}")
+        except PermissionError:
+            print(
+                "Warning: could not write nearby stop report (permission denied)."
+            )
+
+    return result
+
+
+# =============================================================================
+# EXCEL EXPORT
+# =============================================================================
+
+def export_to_excel(df: pd.DataFrame, output_file: str) -> None:
+    """Write DataFrame to Excel with basic formatting and route highlighting."""
     bold_font = Font(bold=True)
+
     with pd.ExcelWriter(output_file, engine="openpyxl") as writer:
-        df.to_excel(writer, index=False, sheet_name="Sheet1")  # Explicit sheet_name
+        df.to_excel(writer, index=False, sheet_name="Sheet1")
         ws = writer.sheets["Sheet1"]
 
-        # left-align header row
+        # Header left-aligned
         for cell in ws[1]:
             cell.alignment = Alignment(horizontal="left")
 
-        # find 1-based column index for route_short_name
-        # Ensure 'route_short_name' is in df.columns
-        if "route_short_name" in df.columns:
-            route_col_idx = df.columns.get_loc("route_short_name") + 1
+        # Bold rows for special routes
+        if "route_short_name" in df.columns and SPECIAL_ROUTES:
+            route_idx = df.columns.get_loc("route_short_name") + 1
+            for row_idx in range(2, ws.max_row + 1):
+                val = ws.cell(row=row_idx, column=route_idx).value
+                if str(val) in SPECIAL_ROUTES:
+                    for c in ws[row_idx]:
+                        c.font = bold_font
 
-            # bold entire row if route_short_name is in SPECIAL_ROUTES
-            # Check if SPECIAL_ROUTES is defined and not empty
-            if "SPECIAL_ROUTES" in globals() and SPECIAL_ROUTES:
-                for row_idx in range(2, ws.max_row + 1):  # Iterate from the first data row
-                    # Get the cell in the route_short_name column for the current row
-                    route_cell = ws.cell(row=row_idx, column=route_col_idx)
-                    if str(route_cell.value) in SPECIAL_ROUTES:
-                        for cell_in_row in ws[row_idx]:  # ws[row_idx] gets all cells in that row
-                            cell_in_row.font = bold_font
-        else:
-            print(
-                "Warning: 'route_short_name' column not found. Cannot apply special route bolding."
-            )
-
-        # auto-fit column widths
-        for idx, col_name in enumerate(df.columns, 1):  # Use col_name from df.columns
-            # Get max length of data in the column
+        # Auto-fit column widths
+        for idx, col_name in enumerate(df.columns, start=1):
             max_len_data = 0
-            if not df[col_name].empty:  # Check if column is not empty
+            if not df[col_name].empty:
                 max_len_data = df[col_name].astype(str).map(len).max()
-
-            # Max length is the greater of header length or data length
-            max_len = max(max_len_data, len(str(col_name))) + 2  # Add a little padding
+            max_len = max(max_len_data, len(str(col_name))) + 2
             ws.column_dimensions[get_column_letter(idx)].width = max_len
 
 
-def process_cluster_data(
+def prepend_sample_row(df: pd.DataFrame, cluster_name: str, schedule_name: str) -> pd.DataFrame:
+    """Prepend a sample row 5 min before the first trip, if possible."""
+    if df.empty:
+        print(
+            f"Warning: empty dataframe for {cluster_name} ({schedule_name}); "
+            "cannot prepend sample row."
+        )
+        return df
+
+    if "arrival_time" not in df.columns or "departure_time" not in df.columns:
+        print(
+            f"Warning: dataframe for {cluster_name} ({schedule_name}) missing "
+            "'arrival_time' or 'departure_time'; cannot prepend sample row."
+        )
+        return df
+
+    sample = {col: "" for col in df.columns}
+    try:
+        first_arr_str = df["arrival_time"].iloc[0]
+        first_dep_str = df["departure_time"].iloc[0]
+
+        first_arr = pd.to_datetime(first_arr_str, format="%H:%M")
+        first_dep = pd.to_datetime(first_dep_str, format="%H:%M")
+
+        sample_arr = (first_arr - pd.Timedelta(minutes=5)).strftime("%H:%M")
+        sample_dep = (first_dep - pd.Timedelta(minutes=5)).strftime("%H:%M")
+
+        updates = {
+            "route_short_name": "SAMPLE",
+            "trip_headsign": "Sample Trip",
+            "arrival_time": sample_arr,
+            "act_arrival": sample_arr,
+            "departure_time": sample_dep,
+            "act_departure": sample_dep,
+            "comments": "Please use 24-hour HH:MM format",
+        }
+        for k, v in updates.items():
+            if k in sample:
+                sample[k] = v
+
+        return pd.concat([pd.DataFrame([sample]), df], ignore_index=True)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"Error creating sample row for {cluster_name} ({schedule_name}): {exc}. "
+            "Proceeding without sample row."
+        )
+        return df
+
+
+def process_cluster_slice(
     cluster_data: pd.DataFrame,
-    stops_df: pd.DataFrame,
     cluster_name: str,
     schedule_name: str,
     base_output_path: str,
     time_windows: Optional[Dict[str, Dict[str, Tuple[str, str]]]] = None,
 ) -> None:
-    """Transform and export a *cluster × schedule* slice.
+    """Transform one cluster×schedule slice and export Excel (full + windows)."""
+    if cluster_data.empty:
+        print(f"No data for {cluster_name} ({schedule_name}); skipping.")
+        return
 
-    Workflow
-    --------
-    1. Normalize and sort times.
-    2. Inject placeholder columns needed for field audits.
-    3. Join readable stop names from *stops.txt*.
-    4. Drop internal GTFS columns not useful to inspectors.
-    5. Emit:
-        * A full-day workbook.
-        * Optional time-window workbooks (e.g. *morning*, *afternoon*).
+    df = cluster_data.copy()
 
-    Args:
-        cluster_data: Subset of stop-times already filtered to the cluster.
-        stops_df: The *stops.txt* table (for name lookup).
-        cluster_name: Friendly cluster label used in filenames.
-        schedule_name: Calendar schedule label used in filenames.
-        base_output_path: Folder for output files.
-        time_windows: Optional mapping
-            ``{"Weekday": {"morning": ("06:00","09:59"), ...}, ...}``.
+    # Normalize times
+    for col in ["arrival_time", "departure_time"]:
+        if col in df.columns:
+            df[col] = df[col].astype(str).map(normalize_gtfs_time_to_hhmm)
 
-    Side Effects:
-        Writes one or more ``*.xlsx`` files and logs progress to ``stdout``.
-    """
-    # ensure we have a copy to avoid SettingWithCopyWarning
-    cluster_data = cluster_data.copy()
-
-    # --- normalize times ---
-    cluster_data["arrival_time"] = cluster_data["arrival_time"].apply(fix_time_format)
-    cluster_data["departure_time"] = cluster_data["departure_time"].apply(fix_time_format)
-    cluster_data["arrival_time"] = cluster_data["arrival_time"].astype(str)
-    cluster_data["departure_time"] = cluster_data["departure_time"].astype(str)
-
-    # --- sort ---
-    # Create a temporary column for proper time sorting, handling potential errors if times are not valid
+    # Sort by arrival_time if possible
     try:
-        cluster_data["arrival_sort"] = pd.to_datetime(
-            cluster_data["arrival_time"], format="%H:%M", errors="raise"
-        )
-        cluster_data = cluster_data.sort_values("arrival_sort").drop(columns=["arrival_sort"])
-    except ValueError as e:
+        df["arrival_sort"] = pd.to_datetime(df["arrival_time"], format="%H:%M")
+        df = df.sort_values("arrival_sort").drop(columns=["arrival_sort"])
+    except Exception as exc:  # noqa: BLE001
         print(
-            f"Warning: Could not sort by arrival_time due to invalid time format for {cluster_name} on {schedule_name}. Error: {e}"
-        )
-        # Proceed without sorting if conversion fails, or handle more gracefully
-
-    # --- placeholders (no act_block) ---
-    cluster_data.insert(cluster_data.columns.get_loc("arrival_time") + 1, "act_arrival", "________")
-    cluster_data.insert(
-        cluster_data.columns.get_loc("departure_time") + 1, "act_departure", "________"
-    )
-    # Ensure 'sequence_long' column exists before trying to use it for loc
-    if "sequence_long" in cluster_data.columns:
-        cluster_data.loc[cluster_data["sequence_long"] == "start", "act_arrival"] = "__XXXX__"
-        cluster_data.loc[cluster_data["sequence_long"] == "last", "act_departure"] = "__XXXX__"
-    else:
-        print(
-            f"Warning: 'sequence_long' column not found in cluster_data for {cluster_name}. Cannot set start/last placeholders."
+            f"Warning: could not sort by arrival_time for {cluster_name} "
+            f"({schedule_name}): {exc}"
         )
 
-    cluster_data["bus_number"] = "________"
-    cluster_data["comments"] = "________________"
+    # Placeholders
+    df.insert(df.columns.get_loc("arrival_time") + 1, "act_arrival", "________")
+    df.insert(df.columns.get_loc("departure_time") + 1, "act_departure", "________")
 
-    # --- merge stop names (using stop_id) ---
-    # Ensure 'stop_id' is the correct merge key and present in both DataFrames
-    if "stop_id" in cluster_data.columns and "stop_id" in stops_df.columns:
-        cluster_data = pd.merge(
-            cluster_data,
-            stops_df[["stop_id", "stop_name"]],  # Only get stop_name
-            on="stop_id",
-            how="left",
-        )
-    else:
-        print(
-            f"Warning: 'stop_id' not found in cluster_data or stops_df for {cluster_name}. Cannot merge stop names."
-        )
+    if "sequence_long" in df.columns:
+        df.loc[df["sequence_long"] == "start", "act_arrival"] = "__XXXX__"
+        df.loc[df["sequence_long"] == "last", "act_departure"] = "__XXXX__"
 
-    # --- reorder columns, show stop_id ---
-    first_cols = [
+    df["bus_number"] = "________"
+    df["comments"] = "________________"
+
+    # Column ordering
+    desired_first = [
         "route_short_name",
         "trip_headsign",
         "stop_sequence",
         "sequence_long",
-        "stop_id",  # Displaying stop_id as per revised request
+        "stop_id",
         "stop_name",
         "arrival_time",
         "act_arrival",
         "departure_time",
         "act_departure",
-        "block_id",  # block_id from GTFS is kept, but no act_block placeholder
+        "block_id",
         "bus_number",
         "comments",
     ]
-    # Ensure all columns in first_cols exist in cluster_data before reordering
-    existing_first_cols = [col for col in first_cols if col in cluster_data.columns]
-    missing_cols = [col for col in first_cols if col not in cluster_data.columns]
-    if missing_cols:
+    existing_first = [c for c in desired_first if c in df.columns]
+    missing_first = [c for c in desired_first if c not in df.columns]
+    if missing_first:
         print(
-            f"Warning: The following expected columns are missing for reordering: {missing_cols} in {cluster_name}"
+            f"Warning: expected columns missing for {cluster_name} "
+            f"({schedule_name}): {missing_first}"
         )
 
-    other_cols = [c for c in cluster_data.columns if c not in existing_first_cols]
-    cluster_data = cluster_data[existing_first_cols + other_cols]
+    other_cols = [c for c in df.columns if c not in existing_first]
+    df = df[existing_first + other_cols]
 
-    # --- drop internal/unnecessary columns (similar to old script, ensuring stop_code is dropped if present) ---
-    columns_to_drop = [
+    # Drop internal / noisy GTFS columns
+    to_drop = [
         "shape_dist_traveled",
         "shape_id",
         "route_id",
@@ -392,218 +605,200 @@ def process_cluster_data(
         "wheelchair_accessible",
         "bikes_allowed",
         "trip_short_name",
-        "stop_code",  # Add stop_code here to drop it, if it exists and stop_id is preferred
+        "stop_code",
     ]
-    # Drop only columns that actually exist in the DataFrame
-    actual_columns_to_drop = [col for col in columns_to_drop if col in cluster_data.columns]
-    cluster_data = cluster_data.drop(columns=actual_columns_to_drop, errors="ignore")
+    df = df.drop(columns=[c for c in to_drop if c in df.columns], errors="ignore")
 
-    # --- helper to prepend sample row 5 min before first trip ---
-    def prepend_sample(df_to_sample: pd.DataFrame) -> pd.DataFrame:
-        if df_to_sample.empty:
-            print(
-                f"Warning: Dataframe for {cluster_name} on {schedule_name} is empty. Cannot prepend sample row."
-            )
-            return df_to_sample  # Return empty df if no data to sample from
+    if not os.path.isdir(base_output_path):
+        print(
+            f"Error: output directory {base_output_path} does not exist; "
+            "cannot write Excel."
+        )
+        return
 
-        sample = {col: "" for col in df_to_sample.columns}
-        try:
-            # use iloc to grab the first row by position
-            first_arr_str = df_to_sample["arrival_time"].iloc[0]
-            first_dep_str = df_to_sample["departure_time"].iloc[0]
-
-            first_arr = pd.to_datetime(first_arr_str, format="%H:%M")
-            first_dep = pd.to_datetime(first_dep_str, format="%H:%M")
-
-            sample_arr_dt = first_arr - pd.Timedelta(minutes=5)
-            sample_dep_dt = first_dep - pd.Timedelta(minutes=5)
-
-            # Handle potential day rollover for sample time if first trip is close to midnight
-            sample_arr = sample_arr_dt.strftime("%H:%M")
-            sample_dep = sample_dep_dt.strftime("%H:%M")
-
-            update_dict = {
-                "route_short_name": "SAMPLE",
-                "trip_headsign": "Sample Trip",
-                "arrival_time": sample_arr,
-                "act_arrival": sample_arr,  # Fill in actuals for sample
-                "departure_time": sample_dep,
-                "act_departure": sample_dep,  # Fill in actuals for sample
-                "comments": "Please use 24-hour HH:MM format",
-            }
-            # Ensure keys in update_dict exist as columns in sample before updating
-            for key, value in update_dict.items():
-                if key in sample:
-                    sample[key] = value
-                else:
-                    print(
-                        f"Warning: Column '{key}' not found in sample row for prepending. Skipping update for this key."
-                    )
-
-            return pd.concat([pd.DataFrame([sample]), df_to_sample], ignore_index=True)
-
-        except (
-            IndexError,
-            TypeError,
-            ValueError,
-        ) as e:  # Catch errors if times are bad or df is unexpectedly empty after check
-            print(
-                f"Error creating sample row for {cluster_name} on {schedule_name}: {e}. Proceeding without sample row."
-            )
-            return df_to_sample
-
-    # --- export full dataset ---
-    # Ensure base_output_path is a directory that exists (or created by create_output_directory)
-    if not os.path.exists(base_output_path):
-        print(f"Error: Output directory {base_output_path} does not exist. Cannot save Excel file.")
-        return  # Exit if path is invalid
-
-    output_file_full_path = os.path.join(
+    # Full-day export
+    full_path = os.path.join(
         base_output_path, f"{cluster_name}_{schedule_name}_data.xlsx"
     )
-    if not cluster_data.empty:
-        df_full_with_sample = prepend_sample(
-            cluster_data.copy()
-        )  # Use .copy() for safety before prepending
-        export_to_excel(df_full_with_sample, output_file_full_path)
-        print(
-            f"Processed and exported {cluster_name} ({schedule_name}) to {output_file_full_path}."
-        )
-    else:
-        print(
-            f"No data to export for {cluster_name} ({schedule_name}). Skipping full dataset export."
-        )
+    df_full = prepend_sample_row(df.copy(), cluster_name, schedule_name)
+    export_to_excel(df_full, full_path)
+    print(f"Exported {cluster_name} ({schedule_name}) full-day to {full_path}")
 
-    # --- export each time window subset ---
-    if time_windows and schedule_name in time_windows and not cluster_data.empty:
+    # Time-window exports
+    if time_windows and schedule_name in time_windows:
         for win_name, (start_s, end_s) in time_windows[schedule_name].items():
             try:
                 st = pd.to_datetime(start_s, format="%H:%M").time()
                 et = pd.to_datetime(end_s, format="%H:%M").time()
-                # Ensure 'arrival_time' is in correct format for conversion
                 atimes = pd.to_datetime(
-                    cluster_data["arrival_time"], format="%H:%M", errors="coerce"
+                    df["arrival_time"], format="%H:%M", errors="coerce"
                 ).dt.time
 
-                # Filter out NaT from atimes if errors were coerced
-                valid_times_mask = pd.notnull(atimes)
-                subset = cluster_data[
-                    valid_times_mask
-                    & (atimes[valid_times_mask] >= st)
-                    & (atimes[valid_times_mask] <= et)
-                ]
+                mask = pd.notnull(atimes) & (atimes >= st) & (atimes <= et)
+                subset = df.loc[mask].copy()
 
                 if subset.empty:
-                    print(f"  No {win_name} data for {cluster_name} ({schedule_name}).")
+                    print(
+                        f"  No {win_name} data for {cluster_name} ({schedule_name})."
+                    )
                     continue
 
-                output_file_window_path = os.path.join(
+                path_win = os.path.join(
                     base_output_path,
                     f"{cluster_name}_{schedule_name}_{win_name}_data.xlsx",
                 )
-                df_sub_with_sample = prepend_sample(subset.copy())  # Use .copy() for safety
-                export_to_excel(df_sub_with_sample, output_file_window_path)
-                print(
-                    f"  Exported {win_name} window for {cluster_name} ({schedule_name}) to {output_file_window_path}."
+                subset_with_sample = prepend_sample_row(
+                    subset, cluster_name, f"{schedule_name} {win_name}"
                 )
-            except ValueError as e:
+                export_to_excel(subset_with_sample, path_win)
                 print(
-                    f"  Error processing time window {win_name} for {cluster_name} ({schedule_name}): {e}. Skipping."
+                    f"  Exported {win_name} for {cluster_name} "
+                    f"({schedule_name}) to {path_win}"
                 )
-    elif cluster_data.empty:
-        print(
-            f"Skipping time window processing for {cluster_name} ({schedule_name}) as main dataset is empty."
-        )
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"  Error processing window {win_name} for {cluster_name} "
+                    f"({schedule_name}): {exc}"
+                )
 
+
+# =============================================================================
+# MAIN ORCHESTRATION
+# =============================================================================
 
 def generate_gtfs_checklists() -> None:
-    """Orchestrate the end-to-end checklist generation process.
-
-    High-level steps:
-        1. Validate inputs and create outputs folder.
-        2. Load GTFS data.
-        3. Loop over each *schedule* and *cluster*,
-           delegating to :pyfunc:`process_cluster_data`.
-
-    The function prints status messages but returns nothing.
-    """
-    # 1) Validate input directory
+    """End-to-end orchestration for GTFS field checklist generation."""
+    # 1. Basic validation and load
     validate_input_directory(BASE_INPUT_PATH, GTFS_FILES)
-
-    # 2) Create output directory
     create_output_directory(BASE_OUTPUT_PATH)
 
-    # 3) Load GTFS data
-    trips, stop_times, routes, stops, calendar = load_gtfs_data(BASE_INPUT_PATH, DTYPE_DICT)
+    trips, stop_times, routes, stops, calendar = load_gtfs_data(
+        BASE_INPUT_PATH, DTYPE_DICT
+    )
 
-    # 4) Potentially replace stop_id with stop_code
-    apply_stop_identifier_mode(stops, STOP_IDENTIFIER_FIELD)
+    # Normalize ids as strings where relevant
+    for df_name, df in [
+        ("trips", trips),
+        ("stop_times", stop_times),
+        ("routes", routes),
+        ("stops", stops),
+        ("calendar", calendar),
+    ]:
+        if "route_id" in df.columns:
+            df["route_id"] = df["route_id"].astype(str)
+        if "trip_id" in df.columns:
+            df["trip_id"] = df["trip_id"].astype(str)
+        if "stop_id" in df.columns:
+            df["stop_id"] = df["stop_id"].astype(str)
+        if "service_id" in df.columns:
+            df["service_id"] = df["service_id"].astype(str)
 
-    # Ensure stop_id is a string in stops
-    stops["stop_id"] = stops["stop_id"].astype(str)
+    # 2. Resolve cluster definitions to canonical stop_ids
+    cluster_stop_ids = build_cluster_stop_ids(
+        stops=stops,
+        clusters=CLUSTERS,
+        identifier_field=STOP_IDENTIFIER_FIELD,
+    )
 
-    # 5) Process each schedule type
+    # Drop clusters that ended up with no valid stop_ids
+    cluster_stop_ids = {
+        cname: ids for cname, ids in cluster_stop_ids.items() if ids
+    }
+
+    if not cluster_stop_ids:
+        print("No valid clusters after resolving identifiers; nothing to process.")
+        return
+
+    # 3. Nearby-stop QA (optional but helpful)
+    _nearby_df = find_nearby_stops_for_clusters(
+        stops=stops,
+        cluster_stop_ids=cluster_stop_ids,
+        buffer_ft=NEARBY_STOP_BUFFER_FT,
+        verbose=True,
+    )
+    if _nearby_df.empty:
+        print(
+            f"No nearby non-cluster stops found within {NEARBY_STOP_BUFFER_FT} ft "
+            "of any cluster."
+        )
+
+    # 4. Process each schedule
     for schedule_name, days in SCHEDULE_TYPES.items():
-        print(f"Processing schedule: {schedule_name}")
+        print(f"\nProcessing schedule: {schedule_name}")
 
-        # Filter calendar by days
+        # Filter calendar to services that run on all requested days
+        for day_col in days:
+            if day_col not in calendar.columns:
+                raise ValueError(
+                    f"calendar.txt missing required column '{day_col}' "
+                    f"for schedule '{schedule_name}'."
+                )
+
         service_mask = calendar[days].astype(bool).all(axis=1)
-        relevant_service_ids = calendar.loc[service_mask, "service_id"]
+        relevant_services = calendar.loc[service_mask, "service_id"].astype(str)
 
-        # Filter trips by relevant service IDs
-        trips_filtered = trips[trips["service_id"].isin(relevant_service_ids)]
-
-        if trips_filtered.empty:
-            print(f"No trips found for {schedule_name} schedule. Skipping.")
+        if relevant_services.empty:
+            print(
+                f"No service_ids active for schedule '{schedule_name}'; "
+                "skipping schedule."
+            )
             continue
 
-        # Merge with stop_times and routes
-        merged_data = pd.merge(stop_times, trips_filtered, on="trip_id")
-        merged_data = pd.merge(merged_data, routes[["route_id", "route_short_name"]], on="route_id")
+        trips_filtered = trips[trips["service_id"].isin(relevant_services)]
+        if trips_filtered.empty:
+            print(
+                f"No trips for schedule '{schedule_name}' after service_id filter; "
+                "skipping schedule."
+            )
+            continue
 
-        # Ensure stop_id is string in merged_data
-        merged_data["stop_id"] = merged_data["stop_id"].astype(str)
+        # Build master joined table for this schedule
+        merged = stop_times.merge(
+            trips_filtered,
+            on="trip_id",
+            how="inner",
+        ).merge(
+            routes[["route_id", "route_short_name"]],
+            on="route_id",
+            how="left",
+        ).merge(
+            stops[["stop_id", "stop_name", "stop_lat", "stop_lon"]],
+            on="stop_id",
+            how="left",
+        )
 
-        # Create sequence_long column
-        merged_data["sequence_long"] = "middle"
-        merged_data.loc[merged_data["stop_sequence"] == 1, "sequence_long"] = "start"
-        max_sequence = merged_data.groupby("trip_id")["stop_sequence"].transform("max")
-        merged_data.loc[merged_data["stop_sequence"] == max_sequence, "sequence_long"] = "last"
+        # Mark start/last in sequence_long
+        merged["stop_sequence"] = merged["stop_sequence"].astype(int)
+        merged["sequence_long"] = "middle"
+        merged.loc[merged["stop_sequence"] == 1, "sequence_long"] = "start"
+        max_seq = merged.groupby("trip_id")["stop_sequence"].transform("max")
+        merged.loc[merged["stop_sequence"] == max_seq, "sequence_long"] = "last"
 
-        # 6) Process each cluster
-        for cluster_name, cluster_stop_ids in CLUSTERS.items():
-            print(f"Processing cluster: {cluster_name} for {schedule_name} schedule")
+        # 5. Cluster loops
+        for cname, id_list in cluster_stop_ids.items():
+            print(f"  Processing cluster '{cname}' for {schedule_name}")
 
-            # Ensure cluster_stop_ids are strings
-            cluster_stop_ids = [str(sid) for sid in cluster_stop_ids]
-
-            # Filter merged data by cluster's stops
-            cluster_data = merged_data[merged_data["stop_id"].isin(cluster_stop_ids)]
-
-            if cluster_data.empty:
-                print(f"No data found for {cluster_name} on {schedule_name} schedule. Skipping.")
+            cluster_slice = merged[merged["stop_id"].isin(id_list)]
+            if cluster_slice.empty:
+                print(
+                    f"  No data found for cluster '{cname}' on schedule "
+                    f"'{schedule_name}'; skipping."
+                )
                 continue
 
-            # Transform and export data
-            process_cluster_data(
-                cluster_data,
-                stops,
-                cluster_name,
-                schedule_name,
-                BASE_OUTPUT_PATH,
+            process_cluster_slice(
+                cluster_data=cluster_slice,
+                cluster_name=cname,
+                schedule_name=schedule_name,
+                base_output_path=BASE_OUTPUT_PATH,
                 time_windows=TIME_WINDOWS,
             )
 
-    print("All clusters and schedules have been processed and exported.")
-
-
-# =============================================================================
-# MAIN
-# =============================================================================
+    print("\nAll clusters and schedules processed.")
 
 
 def main() -> None:
-    """Script entry point: simply calls :pyfunc:`generate_gtfs_checklists`."""
+    """Script entry point."""
     generate_gtfs_checklists()
 
 

--- a/scripts/field_tools/ridecheck_cluster_checklists.py
+++ b/scripts/field_tools/ridecheck_cluster_checklists.py
@@ -127,6 +127,7 @@ _EARTH_RADIUS_M = 6_371_000.0
 # FILE / IO HELPERS
 # =============================================================================
 
+
 def validate_input_directory(base_input_path: str, gtfs_files: Iterable[str]) -> None:
     """Ensure base_input_path exists and contains all GTFS_FILES."""
     if not os.path.isdir(base_input_path):
@@ -154,20 +155,17 @@ def load_gtfs_data(
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Load trips, stop_times, routes, stops, calendar from a GTFS folder."""
     trips = pd.read_csv(os.path.join(base_input_path, "trips.txt"), dtype=dtype_dict)
-    stop_times = pd.read_csv(
-        os.path.join(base_input_path, "stop_times.txt"), dtype=dtype_dict
-    )
+    stop_times = pd.read_csv(os.path.join(base_input_path, "stop_times.txt"), dtype=dtype_dict)
     routes = pd.read_csv(os.path.join(base_input_path, "routes.txt"), dtype=dtype_dict)
     stops = pd.read_csv(os.path.join(base_input_path, "stops.txt"), dtype=dtype_dict)
-    calendar = pd.read_csv(
-        os.path.join(base_input_path, "calendar.txt"), dtype=dtype_dict
-    )
+    calendar = pd.read_csv(os.path.join(base_input_path, "calendar.txt"), dtype=dtype_dict)
     return trips, stop_times, routes, stops, calendar
 
 
 # =============================================================================
 # IDENTIFIER / CLUSTER RESOLUTION
 # =============================================================================
+
 
 def _normalize_identifier_list(values: Iterable[str | int]) -> List[str]:
     """Return a list of str identifiers from a heterogeneous list."""
@@ -229,9 +227,7 @@ def build_cluster_stop_ids(
 
     # identifier_field == "stop_code"
     if "stop_code" not in stops_local.columns:
-        raise ValueError(
-            "identifier_field is 'stop_code' but stops.txt has no 'stop_code' column."
-        )
+        raise ValueError("identifier_field is 'stop_code' but stops.txt has no 'stop_code' column.")
 
     stops_local["stop_code"] = stops_local["stop_code"].astype(str)
 
@@ -275,6 +271,7 @@ def build_cluster_stop_ids(
 # =============================================================================
 # TIME HELPERS
 # =============================================================================
+
 
 def normalize_gtfs_time_to_hhmm(time_str: str) -> str:
     """Normalize GTFS HH:MM[:SS] (possibly ≥ 24h) to 'HH:MM' 0–23h.
@@ -323,9 +320,9 @@ def _haversine_m(
     dlat = lat2r - lat1r
     dlon = lon2r - lon1r
 
-    a = (dlat / 2.0).map(math.sin) ** 2 + math.cos(lat1r) * (
-        lat2r.map(math.cos)
-    ) * ((dlon / 2.0).map(math.sin) ** 2)
+    a = (dlat / 2.0).map(math.sin) ** 2 + math.cos(lat1r) * (lat2r.map(math.cos)) * (
+        (dlon / 2.0).map(math.sin) ** 2
+    )
 
     c = 2 * a.map(math.sqrt).map(lambda x: math.asin(min(1.0, x)))
     return _EARTH_RADIUS_M * c
@@ -373,9 +370,7 @@ def find_nearby_stops_for_clusters(
 
         if anchors.empty:
             if verbose:
-                print(
-                    f"Warning: no anchor stops found for cluster '{cname}' in stops.txt."
-                )
+                print(f"Warning: no anchor stops found for cluster '{cname}' in stops.txt.")
             continue
 
         for _, arow in anchors.iterrows():
@@ -428,14 +423,12 @@ def find_nearby_stops_for_clusters(
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         out_csv = os.path.join(BASE_OUTPUT_PATH, f"nearby_stop_warnings_{ts}.csv")
         try:
-            result.sort_values(
-                ["cluster", "anchor_stop_id", "distance_ft"]
-            ).to_csv(out_csv, index=False)
+            result.sort_values(["cluster", "anchor_stop_id", "distance_ft"]).to_csv(
+                out_csv, index=False
+            )
             print(f"Nearby stop report written to {out_csv}")
         except PermissionError:
-            print(
-                "Warning: could not write nearby stop report (permission denied)."
-            )
+            print("Warning: could not write nearby stop report (permission denied).")
 
     return result
 
@@ -443,6 +436,7 @@ def find_nearby_stops_for_clusters(
 # =============================================================================
 # EXCEL EXPORT
 # =============================================================================
+
 
 def export_to_excel(df: pd.DataFrame, output_file: str) -> None:
     """Write DataFrame to Excel with basic formatting and route highlighting."""
@@ -548,8 +542,7 @@ def process_cluster_slice(
         df = df.sort_values("arrival_sort").drop(columns=["arrival_sort"])
     except Exception as exc:  # noqa: BLE001
         print(
-            f"Warning: could not sort by arrival_time for {cluster_name} "
-            f"({schedule_name}): {exc}"
+            f"Warning: could not sort by arrival_time for {cluster_name} ({schedule_name}): {exc}"
         )
 
     # Placeholders
@@ -610,16 +603,11 @@ def process_cluster_slice(
     df = df.drop(columns=[c for c in to_drop if c in df.columns], errors="ignore")
 
     if not os.path.isdir(base_output_path):
-        print(
-            f"Error: output directory {base_output_path} does not exist; "
-            "cannot write Excel."
-        )
+        print(f"Error: output directory {base_output_path} does not exist; cannot write Excel.")
         return
 
     # Full-day export
-    full_path = os.path.join(
-        base_output_path, f"{cluster_name}_{schedule_name}_data.xlsx"
-    )
+    full_path = os.path.join(base_output_path, f"{cluster_name}_{schedule_name}_data.xlsx")
     df_full = prepend_sample_row(df.copy(), cluster_name, schedule_name)
     export_to_excel(df_full, full_path)
     print(f"Exported {cluster_name} ({schedule_name}) full-day to {full_path}")
@@ -630,17 +618,13 @@ def process_cluster_slice(
             try:
                 st = pd.to_datetime(start_s, format="%H:%M").time()
                 et = pd.to_datetime(end_s, format="%H:%M").time()
-                atimes = pd.to_datetime(
-                    df["arrival_time"], format="%H:%M", errors="coerce"
-                ).dt.time
+                atimes = pd.to_datetime(df["arrival_time"], format="%H:%M", errors="coerce").dt.time
 
                 mask = pd.notnull(atimes) & (atimes >= st) & (atimes <= et)
                 subset = df.loc[mask].copy()
 
                 if subset.empty:
-                    print(
-                        f"  No {win_name} data for {cluster_name} ({schedule_name})."
-                    )
+                    print(f"  No {win_name} data for {cluster_name} ({schedule_name}).")
                     continue
 
                 path_win = os.path.join(
@@ -651,10 +635,7 @@ def process_cluster_slice(
                     subset, cluster_name, f"{schedule_name} {win_name}"
                 )
                 export_to_excel(subset_with_sample, path_win)
-                print(
-                    f"  Exported {win_name} for {cluster_name} "
-                    f"({schedule_name}) to {path_win}"
-                )
+                print(f"  Exported {win_name} for {cluster_name} ({schedule_name}) to {path_win}")
             except Exception as exc:  # noqa: BLE001
                 print(
                     f"  Error processing window {win_name} for {cluster_name} "
@@ -666,15 +647,14 @@ def process_cluster_slice(
 # MAIN ORCHESTRATION
 # =============================================================================
 
+
 def generate_gtfs_checklists() -> None:
     """End-to-end orchestration for GTFS field checklist generation."""
     # 1. Basic validation and load
     validate_input_directory(BASE_INPUT_PATH, GTFS_FILES)
     create_output_directory(BASE_OUTPUT_PATH)
 
-    trips, stop_times, routes, stops, calendar = load_gtfs_data(
-        BASE_INPUT_PATH, DTYPE_DICT
-    )
+    trips, stop_times, routes, stops, calendar = load_gtfs_data(BASE_INPUT_PATH, DTYPE_DICT)
 
     # Normalize ids as strings where relevant
     for df_name, df in [
@@ -701,9 +681,7 @@ def generate_gtfs_checklists() -> None:
     )
 
     # Drop clusters that ended up with no valid stop_ids
-    cluster_stop_ids = {
-        cname: ids for cname, ids in cluster_stop_ids.items() if ids
-    }
+    cluster_stop_ids = {cname: ids for cname, ids in cluster_stop_ids.items() if ids}
 
     if not cluster_stop_ids:
         print("No valid clusters after resolving identifiers; nothing to process.")
@@ -718,8 +696,7 @@ def generate_gtfs_checklists() -> None:
     )
     if _nearby_df.empty:
         print(
-            f"No nearby non-cluster stops found within {NEARBY_STOP_BUFFER_FT} ft "
-            "of any cluster."
+            f"No nearby non-cluster stops found within {NEARBY_STOP_BUFFER_FT} ft of any cluster."
         )
 
     # 4. Process each schedule
@@ -738,10 +715,7 @@ def generate_gtfs_checklists() -> None:
         relevant_services = calendar.loc[service_mask, "service_id"].astype(str)
 
         if relevant_services.empty:
-            print(
-                f"No service_ids active for schedule '{schedule_name}'; "
-                "skipping schedule."
-            )
+            print(f"No service_ids active for schedule '{schedule_name}'; skipping schedule.")
             continue
 
         trips_filtered = trips[trips["service_id"].isin(relevant_services)]
@@ -753,18 +727,22 @@ def generate_gtfs_checklists() -> None:
             continue
 
         # Build master joined table for this schedule
-        merged = stop_times.merge(
-            trips_filtered,
-            on="trip_id",
-            how="inner",
-        ).merge(
-            routes[["route_id", "route_short_name"]],
-            on="route_id",
-            how="left",
-        ).merge(
-            stops[["stop_id", "stop_name", "stop_lat", "stop_lon"]],
-            on="stop_id",
-            how="left",
+        merged = (
+            stop_times.merge(
+                trips_filtered,
+                on="trip_id",
+                how="inner",
+            )
+            .merge(
+                routes[["route_id", "route_short_name"]],
+                on="route_id",
+                how="left",
+            )
+            .merge(
+                stops[["stop_id", "stop_name", "stop_lat", "stop_lon"]],
+                on="stop_id",
+                how="left",
+            )
         )
 
         # Mark start/last in sequence_long


### PR DESCRIPTION
Summary
Rewrite the GTFS field checklist generator for better robustness and configurability,
and add an optional nearby-stop QA report based on haversine distances. The goal is
to make the script safer to run on production GTFS, easier to reconfigure, and better
aligned with the current field workflow.

Key changes
The script now validates the GTFS input directory and required files, normalizes key
IDs as strings, resolves clusters to canonical stop_ids whether they start from
stop_id or stop_code, and centralizes GTFS time normalization (including ≥24h times).
Cluster × schedule processing is handled by process_cluster_slice(), which injects
audit placeholders, marks start/last stops, drops internal GTFS columns, optionally
prepends a sample row, and writes both full-day and time-window Excel outputs.

A nearby-stop QA step runs before the per-cluster loop. For each cluster, it finds
non-cluster stops within the configured buffer in feet and writes an optional
timestamped CSV report when permissions allow.

Impact
This is effectively a rewrite. Output schemas, file names, and cluster handling may
differ from the previous script. Any notebooks or downstream tools that assume the
old format should be reviewed and updated.

BREAKING CHANGE
Checklist generation behavior has changed; the new outputs are not guaranteed to
match the previous script one-to-one.