### PR TITLE
fix: linting errors in stop_impacts_target_routes.py

### DIFF
--- a/scripts/field_tools/ridecheck_results_processor.py
+++ b/scripts/field_tools/ridecheck_results_processor.py
@@ -169,7 +169,7 @@ def flag_on_time(diff_series: pd.Series) -> pd.Series:
         ``'Y'`` if the event is within tolerance, otherwise ``'N'``.
     """
     return diff_series.apply(
-        lambda d: ("Y" if pd.notna(d) and EARLY_TOLERANCE_MIN <= d <= LATE_TOLERANCE_MIN else "N")
+        lambda d: "Y" if pd.notna(d) and EARLY_TOLERANCE_MIN <= d <= LATE_TOLERANCE_MIN else "N"
     )
 
 

--- a/scripts/network_analysis/stop_impacts_target_routes.py
+++ b/scripts/network_analysis/stop_impacts_target_routes.py
@@ -1,17 +1,17 @@
 """GTFS Stop Impact Analyzer.
 
-Parses GTFS data to evaluate the service impact of removing specific target routes 
-(defined in configuration). For every stop served by a target route, the script 
+Parses GTFS data to evaluate the service impact of removing specific target routes
+(defined in configuration). For every stop served by a target route, the script
 determines if the stop is:
 
 1. **Eliminated**: Served *only* by target routes (no alternative service exists).
 2. **Impacted (Route Loss)**: Loses a target route but retains service from others.
 
-The analysis accounts for specific service IDs (calendars) and output includes 
+The analysis accounts for specific service IDs (calendars) and output includes
 Day-of-Week codes to identify if stops are eliminated only on specific days.
 
 Output:
-    Writes `stop_route_calendar_impacts.csv` containing stop-level summaries and 
+    Writes `stop_route_calendar_impacts.csv` containing stop-level summaries and
     per-service-id classifications.
 """
 
@@ -96,7 +96,9 @@ def _svc_ids_to_dow_list(service_ids_csv: str, svc_to_dow: dict[str, str]) -> st
     return ",".join(sorted(set(out)))
 
 
-def _apply_service_id_filter_to_trips(trips: pd.DataFrame, service_filter: set[str] | None) -> pd.DataFrame:
+def _apply_service_id_filter_to_trips(
+    trips: pd.DataFrame, service_filter: set[str] | None
+) -> pd.DataFrame:
     """Optionally filter trips to a subset of service_ids."""
     if service_filter is None:
         return trips
@@ -127,6 +129,14 @@ def _clean_for_export(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def load_gtfs_tables(gtfs_dir: Path) -> dict[str, Optional[pd.DataFrame]]:
+    """Load required GTFS files (stops, routes, trips, stop_times, calendar) from directory.
+
+    Args:
+        gtfs_dir: Path to the directory containing GTFS text files.
+
+    Returns:
+        A dictionary containing loaded DataFrames for each file key.
+    """
     stops = _read_gtfs_csv(
         gtfs_dir,
         "stops.txt",
@@ -191,6 +201,15 @@ def load_gtfs_tables(gtfs_dir: Path) -> dict[str, Optional[pd.DataFrame]]:
 
 
 def identify_target_route_ids(routes: pd.DataFrame, tokens: set[str]) -> set[str]:
+    """Resolve target route IDs from a set of route tokens (short names or IDs).
+
+    Args:
+        routes: The routes DataFrame.
+        tokens: A set of strings to match against route_short_name or route_id.
+
+    Returns:
+        A set of resolved route_id strings found in the GTFS data.
+    """
     r = routes.copy()
     r["route_short_name"] = r["route_short_name"].fillna("").astype(str).str.strip()
     r["route_id"] = r["route_id"].fillna("").astype(str).str.strip()
@@ -198,9 +217,9 @@ def identify_target_route_ids(routes: pd.DataFrame, tokens: set[str]) -> set[str
     mask = r["route_short_name"].isin(tokens) | r["route_id"].isin(tokens)
     target_ids = set(r.loc[mask, "route_id"].astype(str).tolist())
 
-    found_tokens = set(r.loc[r["route_short_name"].isin(tokens), "route_short_name"].tolist()) | set(
-        r.loc[r["route_id"].isin(tokens), "route_id"].tolist()
-    )
+    found_tokens = set(
+        r.loc[r["route_short_name"].isin(tokens), "route_short_name"].tolist()
+    ) | set(r.loc[r["route_id"].isin(tokens), "route_id"].tolist())
     missing = sorted(tokens - found_tokens)
     if missing:
         logging.warning(
@@ -208,7 +227,10 @@ def identify_target_route_ids(routes: pd.DataFrame, tokens: set[str]) -> set[str
             ", ".join(missing),
         )
 
-    logging.info("Target route_ids resolved: %s", ", ".join(sorted(target_ids)) if target_ids else "(none)")
+    logging.info(
+        "Target route_ids resolved: %s",
+        ", ".join(sorted(target_ids)) if target_ids else "(none)",
+    )
     return target_ids
 
 
@@ -217,13 +239,27 @@ def build_stop_service_routes(
     trips: pd.DataFrame,
     routes: pd.DataFrame,
 ) -> pd.DataFrame:
+    """Map every (stop_id, service_id) pair to the list of routes serving it.
+
+    Args:
+        stop_times: The stop_times DataFrame.
+        trips: The trips DataFrame (optionally filtered).
+        routes: The routes DataFrame.
+
+    Returns:
+        A DataFrame with unique (stop_id, service_id) rows and a list of route IDs/labels.
+    """
     merged = stop_times.merge(trips, on="trip_id", how="inner", validate="many_to_one")
     merged = merged.merge(routes, on="route_id", how="left", validate="many_to_one")
 
     rsn = merged["route_short_name"].fillna("").astype(str).str.strip()
-    merged["route_label"] = np.where(rsn.str.len() > 0, rsn, merged["route_id"].astype(str))
+    merged["route_label"] = np.where(
+        rsn.str.len() > 0, rsn, merged["route_id"].astype(str)
+    )
 
-    dedup = merged[["stop_id", "service_id", "route_id", "route_label"]].drop_duplicates()
+    dedup = merged[
+        ["stop_id", "service_id", "route_id", "route_label"]
+    ].drop_duplicates()
 
     route_id_arr = (
         dedup.groupby(["stop_id", "service_id"])["route_id"]
@@ -255,11 +291,20 @@ def attach_calendar_info(
     if calendar is not None and not calendar.empty:
         cal = calendar.copy()
         cal["dow_code"] = cal.apply(_dow_code_from_calendar_row, axis=1)
-        svc_to_dow = dict(zip(cal["service_id"].astype(str), cal["dow_code"].astype(str)))
-        out = out.merge(cal[["service_id", "dow_code"]], on="service_id", how="left", validate="many_to_one")
+        svc_to_dow = dict(
+            zip(cal["service_id"].astype(str), cal["dow_code"].astype(str), strict=True)
+        )
+        out = out.merge(
+            cal[["service_id", "dow_code"]],
+            on="service_id",
+            how="left",
+            validate="many_to_one",
+        )
     else:
         out["dow_code"] = ""
-        logging.warning("calendar.txt missing/empty; dow_code will be blank (days conversion will fall back).")
+        logging.warning(
+            "calendar.txt missing/empty; dow_code will be blank (days conversion will fall back)."
+        )
 
     return out, svc_to_dow
 
@@ -269,12 +314,33 @@ def classify_impacts(
     stops: pd.DataFrame,
     target_route_ids: set[str],
 ) -> pd.DataFrame:
+    """Classify each stop-service pair based on whether it is served by target routes.
+
+    classifications:
+    - not_target: Not served by any target route.
+    - target_only: Served ONLY by target routes (eliminated).
+    - target_plus_other: Served by target routes AND other routes (route loss).
+
+    Args:
+        stop_service_routes: DataFrame mapping stops/services to routes.
+        stops: The stops DataFrame (for attaching location info).
+        target_route_ids: The set of route IDs considered 'target' (to be removed).
+
+    Returns:
+        DataFrame with 'classification' column and stop details attached.
+    """
     out = stop_service_routes.copy()
 
     out["route_id_set"] = out["route_id_arr"].apply(lambda a: set(map(str, a.tolist())))
-    out["target_route_ids_present"] = out["route_id_set"].apply(lambda s: sorted(s & target_route_ids))
-    out["other_route_ids_present"] = out["route_id_set"].apply(lambda s: sorted(s - target_route_ids))
-    out["served_by_any_target"] = out["target_route_ids_present"].apply(lambda lst: len(lst) > 0)
+    out["target_route_ids_present"] = out["route_id_set"].apply(
+        lambda s: sorted(s & target_route_ids)
+    )
+    out["other_route_ids_present"] = out["route_id_set"].apply(
+        lambda s: sorted(s - target_route_ids)
+    )
+    out["served_by_any_target"] = out["target_route_ids_present"].apply(
+        lambda lst: len(lst) > 0
+    )
 
     def _classify_row(row: pd.Series) -> str:
         if not bool(row["served_by_any_target"]):
@@ -306,11 +372,18 @@ def classify_impacts(
     return out
 
 
-def add_stop_level_summary_columns(flagged: pd.DataFrame, svc_to_dow: dict[str, str]) -> pd.DataFrame:
+def add_stop_level_summary_columns(
+    flagged: pd.DataFrame, svc_to_dow: dict[str, str]
+) -> pd.DataFrame:
     """Compute stop-level summary columns and merge back onto each row (single-file workflow)."""
 
     def _svc_list(sub: pd.DataFrame, cls: str) -> str:
-        svc = sorted(sub.loc[sub["classification"] == cls, "service_id"].astype(str).unique().tolist())
+        svc = sorted(
+            sub.loc[sub["classification"] == cls, "service_id"]
+            .astype(str)
+            .unique()
+            .tolist()
+        )
         return ",".join(svc)
 
     rows: list[dict[str, object]] = []
@@ -326,7 +399,9 @@ def add_stop_level_summary_columns(flagged: pd.DataFrame, svc_to_dow: dict[str, 
                 "stop_id": stop_id,
                 "impact_category": impact_category,
                 # clearer names:
-                "has_eliminated_days": bool((sub["classification"] == "target_only").any()),
+                "has_eliminated_days": bool(
+                    (sub["classification"] == "target_only").any()
+                ),
                 "has_route_loss_days": has_plus_other,
                 "service_ids_eliminated": svc_only,
                 "service_ids_route_loss": svc_plus,
@@ -348,7 +423,9 @@ def log_unique_stop_impacts(flagged: pd.DataFrame, stops_universe: pd.DataFrame)
     total_affected = len(flagged_stop_ids)
 
     stop_has_plus_other = (
-        flagged.groupby("stop_id")["classification"].apply(lambda s: (s == "target_plus_other").any()).to_dict()
+        flagged.groupby("stop_id")["classification"]
+        .apply(lambda s: (s == "target_plus_other").any())
+        .to_dict()
     )
     impacted_by_route_loss = {sid for sid, has in stop_has_plus_other.items() if has}
     eliminated_altogether = {sid for sid, has in stop_has_plus_other.items() if not has}
@@ -357,19 +434,22 @@ def log_unique_stop_impacts(flagged: pd.DataFrame, stops_universe: pd.DataFrame)
         return 0.0 if d == 0 else (100.0 * n / d)
 
     logging.info(
-        "Unique platform stops in universe: %d; unique stops affected by targets: %d (%.2f%% of universe)",
+        "Unique platform stops in universe: %d; unique stops affected by targets: %d "
+        "(%.2f%% of universe)",
         total_universe,
         total_affected,
         _pct(total_affected, total_universe),
     )
     logging.info(
-        "Unique stops impacted (route loss, still served by other routes): %d (%.2f%% of universe; %.2f%% of affected)",
+        "Unique stops impacted (route loss, still served by other routes): %d "
+        "(%.2f%% of universe; %.2f%% of affected)",
         len(impacted_by_route_loss),
         _pct(len(impacted_by_route_loss), total_universe),
         _pct(len(impacted_by_route_loss), total_affected),
     )
     logging.info(
-        "Unique stops eliminated (only target routes served them): %d (%.2f%% of universe; %.2f%% of affected)",
+        "Unique stops eliminated (only target routes served them): %d "
+        "(%.2f%% of universe; %.2f%% of affected)",
         len(eliminated_altogether),
         _pct(len(eliminated_altogether), total_universe),
         _pct(len(eliminated_altogether), total_affected),
@@ -377,6 +457,13 @@ def log_unique_stop_impacts(flagged: pd.DataFrame, stops_universe: pd.DataFrame)
 
 
 def write_single_output(df: pd.DataFrame, output_dir: Path, filename: str) -> None:
+    """Write the resulting DataFrame to a CSV file.
+
+    Args:
+        df: The DataFrame to write.
+        output_dir: The directory to write to (will be created if needed).
+        filename: The name of the output CSV file.
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
     out_path = output_dir / filename
     df.to_csv(out_path, index=False)
@@ -389,6 +476,7 @@ def write_single_output(df: pd.DataFrame, output_dir: Path, filename: str) -> No
 
 
 def main() -> None:
+    """Main execution function."""
     logging.basicConfig(level=LOG_LEVEL, format="%(levelname)s | %(message)s")
 
     logging.info("Loading GTFS tables from: %s", GTFS_DIR)
@@ -409,27 +497,42 @@ def main() -> None:
     stops_universe = stops.copy()
     stops_universe["location_type"] = stops_universe["location_type"].fillna("").astype(str)
     if FILTER_TO_PLATFORM_STOPS:
-        stops_universe = stops_universe[stops_universe["location_type"].isin(["", "0"])].copy()
+        stops_universe = stops_universe[
+            stops_universe["location_type"].isin(["", "0"])
+        ].copy()
 
     logging.info("Resolving target routes …")
-    target_route_ids = identify_target_route_ids(routes=routes, tokens=set(TARGET_ROUTE_TOKENS))
+    target_route_ids = identify_target_route_ids(
+        routes=routes, tokens=set(TARGET_ROUTE_TOKENS)
+    )
     if not target_route_ids:
-        raise ValueError("No target routes found. Check TARGET_ROUTE_TOKENS vs routes.txt fields.")
+        raise ValueError(
+            "No target routes found. Check TARGET_ROUTE_TOKENS vs routes.txt fields."
+        )
 
     trips_f = _apply_service_id_filter_to_trips(trips, SERVICE_ID_FILTER)
     if trips_f.empty:
         raise ValueError(
-            "After applying SERVICE_ID_FILTER, no trips remain. Check that the service_ids exist in trips.txt."
+            "After applying SERVICE_ID_FILTER, no trips remain. "
+            "Check that the service_ids exist in trips.txt."
         )
 
     logging.info("Building stop/service -> routes mapping …")
-    stop_service_routes = build_stop_service_routes(stop_times=stop_times, trips=trips_f, routes=routes)
+    stop_service_routes = build_stop_service_routes(
+        stop_times=stop_times, trips=trips_f, routes=routes
+    )
 
     logging.info("Classifying stop impacts …")
-    classified = classify_impacts(stop_service_routes=stop_service_routes, stops=stops, target_route_ids=target_route_ids)
+    classified = classify_impacts(
+        stop_service_routes=stop_service_routes,
+        stops=stops,
+        target_route_ids=target_route_ids,
+    )
 
     logging.info("Attaching calendar info …")
-    classified, svc_to_dow = attach_calendar_info(classified, calendar=calendar if isinstance(calendar, pd.DataFrame) else None)
+    classified, svc_to_dow = attach_calendar_info(
+        classified, calendar=calendar if isinstance(calendar, pd.DataFrame) else None
+    )
 
     # Keep only rows served by at least one target route
     flagged = classified[classified["served_by_any_target"]].copy()
@@ -456,7 +559,9 @@ def main() -> None:
     flagged = _clean_for_export(flagged)
 
     # Impact category ordering + sort
-    impact_order = pd.CategoricalDtype(categories=["eliminated", "route_loss_only"], ordered=True)
+    impact_order = pd.CategoricalDtype(
+        categories=["eliminated", "route_loss_only"], ordered=True
+    )
     flagged["impact_category"] = flagged["impact_category"].astype(impact_order)
 
     if "stop_name" in flagged.columns:
@@ -488,10 +593,14 @@ def main() -> None:
         "service_days_eliminated",
         "service_days_route_loss",
     ]
-    cols = [c for c in preferred_cols if c in flagged.columns] + [c for c in flagged.columns if c not in preferred_cols]
+    cols = [c for c in preferred_cols if c in flagged.columns] + [
+        c for c in flagged.columns if c not in preferred_cols
+    ]
     flagged = flagged[cols]
 
-    logging.info("Flagged rows (stop_id + service_id with target service): %d", len(flagged))
+    logging.info(
+        "Flagged rows (stop_id + service_id with target service): %d", len(flagged)
+    )
     write_single_output(flagged, OUTPUT_DIR, OUTPUT_FILENAME)
 
     logging.info("Done ✔")

--- a/scripts/network_analysis/stop_impacts_target_routes.py
+++ b/scripts/network_analysis/stop_impacts_target_routes.py
@@ -40,7 +40,7 @@ FILTER_TO_PLATFORM_STOPS = True
 # Optional service_id filter:
 # - None to include all service_ids
 # - e.g. {"2","3","4"} to restrict analysis to those calendars only
-SERVICE_ID_FILTER: set[str] | None = {"2", "3", "4"} # Replace with your values
+SERVICE_ID_FILTER: set[str] | None = {"2", "3", "4"}  # Replace with your values
 
 OUTPUT_FILENAME = "stop_route_calendar_impacts.csv"
 
@@ -253,13 +253,9 @@ def build_stop_service_routes(
     merged = merged.merge(routes, on="route_id", how="left", validate="many_to_one")
 
     rsn = merged["route_short_name"].fillna("").astype(str).str.strip()
-    merged["route_label"] = np.where(
-        rsn.str.len() > 0, rsn, merged["route_id"].astype(str)
-    )
+    merged["route_label"] = np.where(rsn.str.len() > 0, rsn, merged["route_id"].astype(str))
 
-    dedup = merged[
-        ["stop_id", "service_id", "route_id", "route_label"]
-    ].drop_duplicates()
+    dedup = merged[["stop_id", "service_id", "route_id", "route_label"]].drop_duplicates()
 
     route_id_arr = (
         dedup.groupby(["stop_id", "service_id"])["route_id"]
@@ -338,9 +334,7 @@ def classify_impacts(
     out["other_route_ids_present"] = out["route_id_set"].apply(
         lambda s: sorted(s - target_route_ids)
     )
-    out["served_by_any_target"] = out["target_route_ids_present"].apply(
-        lambda lst: len(lst) > 0
-    )
+    out["served_by_any_target"] = out["target_route_ids_present"].apply(lambda lst: len(lst) > 0)
 
     def _classify_row(row: pd.Series) -> str:
         if not bool(row["served_by_any_target"]):
@@ -379,10 +373,7 @@ def add_stop_level_summary_columns(
 
     def _svc_list(sub: pd.DataFrame, cls: str) -> str:
         svc = sorted(
-            sub.loc[sub["classification"] == cls, "service_id"]
-            .astype(str)
-            .unique()
-            .tolist()
+            sub.loc[sub["classification"] == cls, "service_id"].astype(str).unique().tolist()
         )
         return ",".join(svc)
 
@@ -399,9 +390,7 @@ def add_stop_level_summary_columns(
                 "stop_id": stop_id,
                 "impact_category": impact_category,
                 # clearer names:
-                "has_eliminated_days": bool(
-                    (sub["classification"] == "target_only").any()
-                ),
+                "has_eliminated_days": bool((sub["classification"] == "target_only").any()),
                 "has_route_loss_days": has_plus_other,
                 "service_ids_eliminated": svc_only,
                 "service_ids_route_loss": svc_plus,
@@ -497,18 +486,12 @@ def main() -> None:
     stops_universe = stops.copy()
     stops_universe["location_type"] = stops_universe["location_type"].fillna("").astype(str)
     if FILTER_TO_PLATFORM_STOPS:
-        stops_universe = stops_universe[
-            stops_universe["location_type"].isin(["", "0"])
-        ].copy()
+        stops_universe = stops_universe[stops_universe["location_type"].isin(["", "0"])].copy()
 
     logging.info("Resolving target routes …")
-    target_route_ids = identify_target_route_ids(
-        routes=routes, tokens=set(TARGET_ROUTE_TOKENS)
-    )
+    target_route_ids = identify_target_route_ids(routes=routes, tokens=set(TARGET_ROUTE_TOKENS))
     if not target_route_ids:
-        raise ValueError(
-            "No target routes found. Check TARGET_ROUTE_TOKENS vs routes.txt fields."
-        )
+        raise ValueError("No target routes found. Check TARGET_ROUTE_TOKENS vs routes.txt fields.")
 
     trips_f = _apply_service_id_filter_to_trips(trips, SERVICE_ID_FILTER)
     if trips_f.empty:
@@ -559,9 +542,7 @@ def main() -> None:
     flagged = _clean_for_export(flagged)
 
     # Impact category ordering + sort
-    impact_order = pd.CategoricalDtype(
-        categories=["eliminated", "route_loss_only"], ordered=True
-    )
+    impact_order = pd.CategoricalDtype(categories=["eliminated", "route_loss_only"], ordered=True)
     flagged["impact_category"] = flagged["impact_category"].astype(impact_order)
 
     if "stop_name" in flagged.columns:
@@ -598,9 +579,7 @@ def main() -> None:
     ]
     flagged = flagged[cols]
 
-    logging.info(
-        "Flagged rows (stop_id + service_id with target service): %d", len(flagged)
-    )
+    logging.info("Flagged rows (stop_id + service_id with target service): %d", len(flagged))
     write_single_output(flagged, OUTPUT_DIR, OUTPUT_FILENAME)
 
     logging.info("Done ✔")

--- a/scripts/service_coverage_geotools/gtfs_census_catchment_analysis_gpd.py
+++ b/scripts/service_coverage_geotools/gtfs_census_catchment_analysis_gpd.py
@@ -456,13 +456,15 @@ def do_route_by_route_analysis(
 
     # Apply variable buffer logic
     stops_gdf["buffer_distance_meters"] = stops_gdf["stop_id"].apply(
-        lambda sid: pick_buffer_distance(
-            sid,
-            normal_buffer=buffer_distance_mi,
-            large_buffer=large_buffer_distance_mi,
-            large_buffer_ids=stop_ids_large_buffer,
+        lambda sid: (
+            pick_buffer_distance(
+                sid,
+                normal_buffer=buffer_distance_mi,
+                large_buffer=large_buffer_distance_mi,
+                large_buffer_ids=stop_ids_large_buffer,
+            )
+            * 1609.34
         )
-        * 1609.34
     )
     stops_gdf["geometry"] = stops_gdf.apply(
         lambda row: row.geometry.buffer(row["buffer_distance_meters"]), axis=1
@@ -567,13 +569,15 @@ def do_stop_by_stop_analysis(
 
     # Apply variable buffer logic
     stops_gdf["buffer_distance_meters"] = stops_gdf["stop_id"].apply(
-        lambda sid: pick_buffer_distance(
-            sid,
-            normal_buffer=buffer_distance_mi,
-            large_buffer=large_buffer_distance_mi,
-            large_buffer_ids=stop_ids_large_buffer,
+        lambda sid: (
+            pick_buffer_distance(
+                sid,
+                normal_buffer=buffer_distance_mi,
+                large_buffer=large_buffer_distance_mi,
+                large_buffer_ids=stop_ids_large_buffer,
+            )
+            * 1609.34
         )
-        * 1609.34
     )
 
     # For each stop, create a buffer, clip, and store results

--- a/tests/test_load_gtfs_data.py
+++ b/tests/test_load_gtfs_data.py
@@ -5,7 +5,6 @@ from typing import Iterable
 
 import pandas as pd
 import pytest
-
 from helpers.gtfs_helpers import load_gtfs_data
 
 


### PR DESCRIPTION
This PR addresses linting errors in `scripts/network_analysis/stop_impacts_target_routes.py` reported by the weekly checker.

Changes include:
- Adding docstrings to `load_gtfs_tables`, `identify_target_route_ids`, `build_stop_service_routes`, `classify_impacts`, `write_single_output`, and `main`.
- Enforcing `strict=True` in a `zip` operation.
- Refactoring long strings in logging and exceptions to comply with the 100-character line limit.
- Minor formatting adjustments.

---
*PR created automatically by Jules for task [5580133696676861271](https://jules.google.com/task/5580133696676861271) started by @zekrowm*