### PR TITLE
feat: Add CLEVER to TIDES conversion scripts

### DIFF
--- a/scripts/operations_tools/clever_to_tides_stop_visits.py
+++ b/scripts/operations_tools/clever_to_tides_stop_visits.py
@@ -194,11 +194,7 @@ def parse_route_short(route_text: pd.Series) -> pd.Series:
 def normalize_vehicle_id(vehicle_series: pd.Series) -> pd.Series:
     """Normalize vehicle id values (handle floats like '7906.0', trim whitespace)."""
     s = normalize_text(vehicle_series)
-    return (
-        s.str.replace(r"\.0$", "", regex=True)
-        .replace({"<NA>": pd.NA})
-        .astype("string")
-    )
+    return s.str.replace(r"\.0$", "", regex=True).replace({"<NA>": pd.NA}).astype("string")
 
 
 def normalize_dt_series(series: pd.Series) -> pd.Series:

--- a/scripts/operations_tools/clever_to_tides_stop_visits.py
+++ b/scripts/operations_tools/clever_to_tides_stop_visits.py
@@ -1,0 +1,531 @@
+"""Convert CLEVER export into TIDES-compliant stop_visits records.
+
+This module reads a CLEVER “Stop Visit Events” report (CSV) and produces a
+`stop_visits.csv` file aligned with the TIDES `stop_visits` schema. It
+normalizes common real-world export issues (inconsistent whitespace, AM/PM
+timestamps, mixed null tokens) and applies pragmatic, schema-aware rules so
+the output can be ingested by downstream validation and analytics pipelines.
+
+The CLEVER Stop Visit Events report is timepoint-based rather than true stop-
+ordered. This converter therefore preserves CLEVER `Timepoint Order` values
+as both `trip_stop_sequence` and `scheduled_stop_sequence`. While this may
+violate strict stop-order expectations in the TIDES schema, it reflects the
+best available ordering in the source data. Potential sequencing issues are
+logged for visibility.
+
+Key behaviors:
+- Parses scheduled and actual stop timestamps robustly (tolerates AM/PM,
+  inconsistent whitespace, and partial availability). Rows are not dropped
+  solely due to incomplete timing data.
+- Uses Scheduled Passing Time for scheduled arrival and departure when
+  present. Uses Arrival Time and Departure Time for actual stop times, with
+  fallback to Actual Time when needed.
+- Computes `dwell` in seconds when actual arrival and departure are present
+  and non-negative; invalid dwell values are left blank and logged.
+- Derives `service_date` from the CLEVER Date field and extracts
+  `trip_id_performed` from the CLEVER Trip token (or a stable derived
+  identifier when configured to match a hashed `trips_performed` strategy).
+- Extracts `stop_id` from CLEVER Timepoint ID, marks all records as
+  `timepoint = True`, and synthesizes `pattern_id` from available route,
+  direction, and variation fields.
+- Emits schema-required fields using schema-valid types and enum values, and
+  leaves unsupported stop-level attributes (APC, door events, ramp activity,
+  revenue) blank with explicit warnings.
+
+The conversion is deterministic: given the same input file and configuration,
+the output identifiers and records are stable across runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+INPUT_CSV: Path = Path(r"Path\To\Stop Visit Events.csv")
+OUTPUT_CSV: Path = Path(r"Path\To\stop_visits.csv")
+
+# Trip ID strategy:
+# - "token": trip_id_performed = second token in CLEVER "Trip" (default)
+# - "hashed": trip_id_performed = stable hash of (service_date, trip_token, vehicle_id)
+#
+# If you already generate trip_id_performed in trips_performed.csv as a hash, use "hashed" here too.
+TRIP_ID_MODE: str = "token"  # "token" | "hashed"
+
+# Column names that may vary between CLEVER exports (edit as needed).
+DATE_COL: str = "Date"
+TRIP_COL: str = "Trip"
+ROUTE_COL: str = "Route"
+DIRECTION_COL: str = "Direction"
+VEHICLE_COL: str = "Vehicle"
+VARIATION_COL: str = "Variation"
+TIMEPOINT_ORDER_COL: str = "Timepoint Order"
+TIMEPOINT_ID_COL: str = "Timepoint ID"
+
+# Updated time columns (present in your new sample).
+ACTUAL_TIME_COL: str = "Actual Time"
+ARRIVAL_TIME_COL: str = "Arrival Time"
+DEPARTURE_TIME_COL: str = "Departure Time"
+SCHEDULED_PASSING_TIME_COL: str = "Scheduled Passing Time"
+
+# TIDES stop_visits output columns in the exact order of the template.
+TIDES_COLS: list[str] = [
+    "service_date",
+    "trip_id_performed",
+    "trip_stop_sequence",
+    "scheduled_stop_sequence",
+    "pattern_id",
+    "vehicle_id",
+    "dwell",
+    "stop_id",
+    "timepoint",
+    "schedule_arrival_time",
+    "schedule_departure_time",
+    "actual_arrival_time",
+    "actual_departure_time",
+    "distance",
+    "boarding_1",
+    "alighting_1",
+    "boarding_2",
+    "alighting_2",
+    "departure_load",
+    "door_open",
+    "door_close",
+    "door_status",
+    "ramp_deployed_time",
+    "ramp_failure",
+    "kneel_deployed_time",
+    "lift_deployed_time",
+    "bike_rack_deployed",
+    "bike_load",
+    "revenue",
+    "number_of_transactions",
+    "schedule_relationship",
+]
+
+# Minimal required CLEVER columns to produce a useful stop_visits file.
+REQ_COLS: list[str] = [
+    DATE_COL,
+    TRIP_COL,
+    TIMEPOINT_ORDER_COL,
+    TIMEPOINT_ID_COL,
+]
+
+# Optional CLEVER columns (used when present).
+OPT_COLS: list[str] = [
+    ROUTE_COL,
+    DIRECTION_COL,
+    VEHICLE_COL,
+    VARIATION_COL,
+    ACTUAL_TIME_COL,
+    ARRIVAL_TIME_COL,
+    DEPARTURE_TIME_COL,
+    SCHEDULED_PASSING_TIME_COL,
+]
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def normalize_text(series: pd.Series) -> pd.Series:
+    """Normalize text values: strip, collapse whitespace, coerce common blanks to NA."""
+    return (
+        series.astype("string")
+        .str.strip()
+        .str.replace(r"\s+", " ", regex=True)
+        .replace({"": pd.NA, "nan": pd.NA, "NaN": pd.NA, "N/A": pd.NA})
+    )
+
+
+def parse_service_date(date_series: pd.Series) -> pd.Series:
+    """Parse CLEVER Date (m/d/YYYY) into ISO service_date (YYYY-MM-DD)."""
+    s = normalize_text(date_series)
+    dt = pd.to_datetime(s, errors="coerce", format="%m/%d/%Y")
+    bad = int(dt.isna().sum())
+    if bad:
+        logging.warning("Failed to parse %d Date values; emitting blanks for those rows.", bad)
+    return dt.dt.strftime("%Y-%m-%d").astype("string")
+
+
+def split_trip_token(trip_series: pd.Series) -> pd.Series:
+    """Extract the second token from CLEVER Trip like "04:02 1550064" -> "1550064".
+
+    If parsing fails, emits NA and logs a warning.
+    """
+    s = normalize_text(trip_series).fillna("")
+    parts = s.str.split(r"\s+", n=1, expand=True)
+
+    trip_token = (
+        parts[1].astype("string").fillna("").str.strip()
+        if parts.shape[1] > 1
+        else pd.Series("", index=s.index, dtype="string")
+    )
+
+    if (trip_token == "").any():
+        logging.warning(
+            "Some Trip values did not include a second token (trip token). "
+            "trip_id_performed may be blank for those rows."
+        )
+
+    return trip_token.replace({"": pd.NA}).astype("string")
+
+
+def stable_id(*parts: str) -> str:
+    """Short deterministic ID from multiple fields (sha1 truncated)."""
+    raw = "||".join(parts).encode("utf-8")
+    return hashlib.sha1(raw).hexdigest()[:16]
+
+
+def parse_route_short(route_text: pd.Series) -> pd.Series:
+    """Route like '101 - Fort Hunt - Mount Vernon' -> '101' (best-effort)."""
+    s = normalize_text(route_text).fillna("")
+    left = s.str.split("-", n=1, expand=True)[0].astype("string").str.strip()
+    digits = left.str.extract(r"^\s*([0-9A-Za-z]+)\s*$")[0]
+    return digits.fillna(left).replace({"": pd.NA}).astype("string")
+
+
+def normalize_vehicle_id(vehicle_series: pd.Series) -> pd.Series:
+    """Normalize vehicle id values (handle floats like '7906.0', trim whitespace)."""
+    s = normalize_text(vehicle_series)
+    return (
+        s.str.replace(r"\.0$", "", regex=True)
+        .replace({"<NA>": pd.NA})
+        .astype("string")
+    )
+
+
+def normalize_dt_series(series: pd.Series) -> pd.Series:
+    """Normalize datetime-like strings prior to pandas parsing."""
+    return normalize_text(series)
+
+
+def parse_dt(series: pd.Series, *, col_name: str) -> pd.Series:
+    """Parse datetime series robustly; logs count of unparseable values."""
+    dt = pd.to_datetime(
+        normalize_dt_series(series),
+        errors="coerce",
+        infer_datetime_format=True,
+    )
+    bad = int(dt.isna().sum())
+    if bad:
+        logging.warning("Failed to parse %d values in %r.", bad, col_name)
+    return dt
+
+
+def dt_to_iso(series: pd.Series) -> pd.Series:
+    """Datetime -> ISO string (YYYY-MM-DDTHH:MM:SS); NaT -> NA."""
+    return series.dt.strftime("%Y-%m-%dT%H:%M:%S").astype("string")
+
+
+def warn_missing_columns(df: pd.DataFrame) -> None:
+    """Check for missing columns and log warnings or raise errors."""
+    missing_req = [c for c in REQ_COLS if c not in df.columns]
+    if missing_req:
+        raise ValueError(f"Missing required CLEVER columns: {missing_req}")
+
+    missing_opt = [c for c in OPT_COLS if c not in df.columns]
+    if missing_opt:
+        logging.warning("Missing optional CLEVER columns (will continue): %s", missing_opt)
+
+
+def normalize_timepoint_order(series: pd.Series) -> pd.Series:
+    """Parse Timepoint Order as integer-ish sequence.
+
+    Policy:
+    - If values parse as numeric:
+        - if any are 0, we shift those by +1 and warn (schema expects min 1).
+        - if any are < 0, we drop them to NA and warn.
+    - If unparseable, NA with warning elsewhere.
+    """
+    seq = pd.to_numeric(series, errors="coerce")
+
+    neg = seq.notna() & (seq < 0)
+    if neg.any():
+        logging.warning(
+            "Found %d rows with negative %r; setting those sequences to blank.",
+            int(neg.sum()),
+            TIMEPOINT_ORDER_COL,
+        )
+        seq = seq.mask(neg)
+
+    zeros = seq.notna() & (seq == 0)
+    if zeros.any():
+        logging.warning(
+            "Found %d rows with %r == 0; shifting those to 1 (adding +1).",
+            int(zeros.sum()),
+            TIMEPOINT_ORDER_COL,
+        )
+        seq = seq.mask(zeros, 1)
+
+    # Keep as nullable Int64
+    return seq.round(0).astype("Int64")
+
+
+def warn_nonconsecutive_sequences(
+    df_out: pd.DataFrame,
+    *,
+    service_date_col: str = "service_date",
+    trip_id_col: str = "trip_id_performed",
+    seq_col: str = "trip_stop_sequence",
+) -> None:
+    """Warn if sequences within (service_date, trip_id_performed) are not consecutive starting at 1.
+
+    We do NOT fix them (user asked to accept timepoint order), but we do make it visible.
+    """
+    if df_out.empty:
+        return
+
+    key_cols = [service_date_col, trip_id_col]
+    missing_keys = [c for c in key_cols + [seq_col] if c not in df_out.columns]
+    if missing_keys:
+        return
+
+    tmp = df_out[key_cols + [seq_col]].copy()
+    tmp = tmp.dropna(subset=key_cols, how="any")
+
+    def _is_consecutive(s: pd.Series) -> bool:
+        vals = pd.to_numeric(s, errors="coerce").dropna().astype(int).tolist()
+        if not vals:
+            return True
+        vals_sorted = sorted(set(vals))
+        return vals_sorted[0] == 1 and vals_sorted == list(range(1, vals_sorted[-1] + 1))
+
+    bad_groups = 0
+    for _, g in tmp.groupby(key_cols, dropna=False):
+        if not _is_consecutive(g[seq_col]):
+            bad_groups += 1
+
+    if bad_groups:
+        logging.warning(
+            "Timepoint-based sequencing: %d trip(s) have non-consecutive %r values. "
+            "This may violate strict TIDES schema expectations for stop order.",
+            bad_groups,
+            seq_col,
+        )
+
+
+# =============================================================================
+# CORE CONVERSION
+# =============================================================================
+
+
+def clever_to_tides(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert CLEVER Stop Visit Events export to TIDES stop_visits.csv."""
+    df = df.dropna(how="all").copy()
+    warn_missing_columns(df)
+
+    out = pd.DataFrame(index=df.index)
+
+    # service_date
+    out["service_date"] = parse_service_date(df[DATE_COL])
+
+    # Trip token + vehicle_id (needed for optional hashed ID mode)
+    trip_token = split_trip_token(df[TRIP_COL])
+
+    if VEHICLE_COL in df.columns:
+        vehicle_id = normalize_vehicle_id(df[VEHICLE_COL])
+    else:
+        vehicle_id = pd.Series(pd.NA, index=df.index, dtype="string")
+
+    # trip_id_performed
+    trip_id_mode = str(TRIP_ID_MODE).strip().lower()
+    if trip_id_mode not in {"token", "hashed"}:
+        logging.warning("TRIP_ID_MODE=%r is invalid; defaulting to 'token'.", TRIP_ID_MODE)
+        trip_id_mode = "token"
+
+    if trip_id_mode == "token":
+        out["trip_id_performed"] = trip_token
+    else:
+        # Hash inputs to align with a hashed trips_performed strategy
+        # Note: if your trips_performed hash uses different fields, change this to match exactly.
+        service_date_str = out["service_date"].fillna("").astype("string")
+        trip_tok_str = trip_token.fillna("").astype("string")
+        veh_str = vehicle_id.fillna("").astype("string")
+
+        out["trip_id_performed"] = [
+            f"perf_{stable_id(str(sd), str(tt), str(vv))}"
+            for sd, tt, vv in zip(service_date_str, trip_tok_str, veh_str, strict=True)
+        ]
+        out["trip_id_performed"] = pd.Series(
+            out["trip_id_performed"], index=df.index, dtype="string"
+        ).replace({"perf_" + stable_id("", "", ""): pd.NA})
+
+    # sequences + stop_id
+    seq = normalize_timepoint_order(df[TIMEPOINT_ORDER_COL])
+    bad_seq = int(seq.isna().sum())
+    if bad_seq:
+        logging.warning(
+            "Failed to parse %d %r values as integers; emitting blanks for those rows.",
+            bad_seq,
+            TIMEPOINT_ORDER_COL,
+        )
+
+    out["trip_stop_sequence"] = seq
+    out["scheduled_stop_sequence"] = seq
+
+    out["stop_id"] = normalize_text(df[TIMEPOINT_ID_COL])
+
+    # vehicle_id
+    out["vehicle_id"] = vehicle_id
+    if out["vehicle_id"].isna().any():
+        logging.warning("vehicle_id is missing on %d rows.", int(out["vehicle_id"].isna().sum()))
+
+    # pattern_id (synthetic)
+    route_short = (
+        parse_route_short(df[ROUTE_COL])
+        if ROUTE_COL in df.columns
+        else pd.Series(pd.NA, index=df.index)
+    )
+    direction = (
+        normalize_text(df[DIRECTION_COL])
+        if DIRECTION_COL in df.columns
+        else pd.Series(pd.NA, index=df.index)
+    )
+
+    if VARIATION_COL in df.columns:
+        var = pd.to_numeric(df[VARIATION_COL], errors="coerce").astype("Int64").astype("string")
+        var = var.replace({"<NA>": pd.NA})
+    else:
+        var = pd.Series(pd.NA, index=df.index, dtype="string")
+
+    pattern = (
+        route_short.fillna("").astype("string").str.strip()
+        + "|"
+        + direction.fillna("").astype("string").str.strip()
+        + "|"
+        + var.fillna("").astype("string").str.strip()
+    ).str.strip("|")
+    out["pattern_id"] = pattern.replace({"": pd.NA}).astype("string")
+
+    # timepoint flag (boolean per schema)
+    out["timepoint"] = True
+
+    # --- Times: scheduled + actual
+    # Scheduled Passing Time -> schedule_arrival_time + schedule_departure_time
+    if SCHEDULED_PASSING_TIME_COL in df.columns:
+        sched_dt = parse_dt(df[SCHEDULED_PASSING_TIME_COL], col_name=SCHEDULED_PASSING_TIME_COL)
+        sched_iso = dt_to_iso(sched_dt).where(sched_dt.notna(), pd.NA)
+        out["schedule_arrival_time"] = sched_iso
+        out["schedule_departure_time"] = sched_iso
+    else:
+        out["schedule_arrival_time"] = pd.NA
+        out["schedule_departure_time"] = pd.NA
+
+    # Arrival/Departure -> actual arrival/departure; fallback to Actual Time
+    arrival_dt = (
+        parse_dt(df[ARRIVAL_TIME_COL], col_name=ARRIVAL_TIME_COL)
+        if ARRIVAL_TIME_COL in df.columns
+        else pd.Series(pd.NaT, index=df.index)
+    )
+    depart_dt = (
+        parse_dt(df[DEPARTURE_TIME_COL], col_name=DEPARTURE_TIME_COL)
+        if DEPARTURE_TIME_COL in df.columns
+        else pd.Series(pd.NaT, index=df.index)
+    )
+    actual_dt = (
+        parse_dt(df[ACTUAL_TIME_COL], col_name=ACTUAL_TIME_COL)
+        if ACTUAL_TIME_COL in df.columns
+        else pd.Series(pd.NaT, index=df.index)
+    )
+
+    arrival_best = arrival_dt.where(arrival_dt.notna(), actual_dt)
+    depart_best = depart_dt.where(depart_dt.notna(), actual_dt)
+
+    out["actual_arrival_time"] = dt_to_iso(arrival_best).where(arrival_best.notna(), pd.NA)
+    out["actual_departure_time"] = dt_to_iso(depart_best).where(depart_best.notna(), pd.NA)
+
+    # dwell seconds (only when both present and non-negative)
+    dwell_sec = (depart_best - arrival_best).dt.total_seconds()
+    dwell_ok = dwell_sec.notna() & (dwell_sec >= 0)
+    if (~dwell_ok & dwell_sec.notna()).any():
+        logging.warning(
+            "Found %d rows with negative dwell (departure before arrival); "
+            "leaving dwell blank for those rows.",
+            int((~dwell_ok & dwell_sec.notna()).sum()),
+        )
+    out["dwell"] = dwell_sec.where(dwell_ok, pd.NA).round(0).astype("Int64")
+
+    # Fields CLEVER Stop Visit Events doesn't provide: leave blank
+    blanks = [
+        "distance",
+        "boarding_1",
+        "alighting_1",
+        "boarding_2",
+        "alighting_2",
+        "departure_load",
+        "door_open",
+        "door_close",
+        "door_status",
+        "ramp_deployed_time",
+        "ramp_failure",
+        "kneel_deployed_time",
+        "lift_deployed_time",
+        "bike_rack_deployed",
+        "bike_load",
+        "revenue",
+        "number_of_transactions",
+    ]
+    for c in blanks:
+        out[c] = pd.NA
+
+    # schedule_relationship: schema enum value
+    out["schedule_relationship"] = "Scheduled"
+
+    # Warn about strict-schema expectations we are knowingly violating / risking
+    warn_nonconsecutive_sequences(out)
+
+    # Minimal sanity warnings
+    if out["service_date"].isna().any():
+        logging.warning(
+            "service_date is missing on %d rows.", int(out["service_date"].isna().sum())
+        )
+    if out["stop_id"].isna().any():
+        logging.warning("stop_id is missing on %d rows.", int(out["stop_id"].isna().sum()))
+    if out["trip_id_performed"].isna().any():
+        logging.warning(
+            "trip_id_performed is missing on %d rows.", int(out["trip_id_performed"].isna().sum())
+        )
+    if out["trip_stop_sequence"].isna().any():
+        logging.warning(
+            "trip_stop_sequence is missing on %d rows (unparseable %r).",
+            int(out["trip_stop_sequence"].isna().sum()),
+            TIMEPOINT_ORDER_COL,
+        )
+
+    # Final order + stable dtypes for CSV output
+    out = out.reindex(columns=TIDES_COLS)
+
+    # Convert nullable Int64 columns to plain strings/blank for cleaner CSV, if desired.
+    # Keep as numeric if you prefer strict typing in downstream ingestion.
+    # Here we keep numeric for seq + dwell, which is generally what schemas expect.
+    return out
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+
+def main() -> None:
+    """Run the conversion pipeline."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    df = pd.read_csv(INPUT_CSV, low_memory=False)
+    logging.info("Read %d rows, %d columns", len(df), df.shape[1])
+
+    out = clever_to_tides(df)
+
+    OUTPUT_CSV.parent.mkdir(parents=True, exist_ok=True)
+    out.to_csv(OUTPUT_CSV, index=False)
+    logging.info("Wrote %d rows -> %s", len(out), OUTPUT_CSV)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/operations_tools/clever_to_tides_trips_performed.py
+++ b/scripts/operations_tools/clever_to_tides_trips_performed.py
@@ -1,0 +1,450 @@
+"""Convert CLEVER export into TIDES-compliant trips_performed records.
+
+This module reads a CLEVER “Event Runtime Analysis” report (CSV) and produces a
+`trips_performed.csv` file that conforms to the TIDES `trips_performed` schema.
+It normalizes common real-world export issues (inconsistent whitespace, AM/PM
+timestamps, mixed null tokens) and applies schema-aligned data quality rules so
+the output can be ingested by downstream validation and analytics pipelines.
+
+Key behaviors:
+- Parses scheduled and actual timestamps robustly (tolerates AM/PM and extra
+  whitespace). Missing start/end times are permitted; rows are not dropped solely
+  for partial timing data.
+- Derives `service_date` from Scheduled Start Time when available, otherwise
+  falls back to Actual Start Time. Rows that cannot be dated are excluded.
+- Requires `vehicle_id` (as per schema). Rows with missing or unusable vehicle
+  identifiers are excluded and counted in logs.
+- Extracts `route_id` from the human-readable Route field by taking the token to
+  the left of "-" and trimming whitespace (e.g., "301 - Telegraph Rd" -> "301").
+- Preserves the CLEVER TripID as `trip_id_scheduled` when it matches the GTFS
+  `trip_id`. `trip_id_performed` is chosen to remain unique within `service_date`
+  (using the scheduled trip id when safe, otherwise a stable derived identifier).
+- Optionally filters to a single CLEVER Trip Type (e.g., "Revenue"). When
+  enabled, the module logs how many rows were removed by each other trip type.
+- Maps CLEVER Trip Type values into the schema-constrained TIDES `trip_type`
+  enumeration (e.g., "Revenue" -> "In service", "Pull-In" -> "Pullin").
+
+The conversion is designed to be deterministic: given the same input file and
+configuration, the output identifiers and records are stable across runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+INPUT_CSV: Path = Path(r"Path\To\Event Runtime Analysis.csv")
+OUTPUT_CSV: Path = Path(r"Path\To\trips_performed.csv")
+
+# If set (e.g., "Revenue"), keeps only CLEVER Trip Type == this value.
+# If None/blank, keeps everything and logs nothing about filtering.
+KEEP_CLEVER_TRIP_TYPE: str | None = "Revenue"
+
+# Column names that may vary between exports (edit as needed).
+OPERATOR_COL: str = "Operator"
+
+# Set these to match your export headers.
+TRIP_START_STOP_COL: str | None = None  # e.g., "First Stop"
+TRIP_END_STOP_COL: str | None = "Last Stop"  # e.g., "Last Stop"
+
+# Direction mapping. Must be 0/1 if present; unmapped values -> NA.
+DIRECTION_TEXT_TO_ID: dict[str, int] = {
+    "NORTHBOUND": 0,
+    "WESTBOUND": 0,
+    "SOUTHBOUND": 1,
+    "EASTBOUND": 1,
+}
+
+# CLEVER Trip Type -> TIDES schema trip_type enum
+# Allowed enum values include: "In service", "Deadhead", "Pullout", "Pullin", ...
+# (see schema for full list)
+CLEVER_TO_TIDES_TRIP_TYPE: dict[str, str] = {
+    "REVENUE": "In service",
+    "DEADHEAD": "Deadhead",
+    "LAYOVER": "Layover",
+    "PULL-OUT": "Pullout",
+    "PULL OUT": "Pullout",
+    "PULL OUT ": "Pullout",
+    "PULLOUT": "Pullout",
+    "PULL-IN": "Pullin",
+    "PULL IN": "Pullin",
+    "PULLIN": "Pullin",
+    # If you have agency-specific labels, map them here.
+}
+
+# Output columns per schema (do NOT include "date"—schema does not define it).
+TIDES_COLS: list[str] = [
+    "service_date",
+    "trip_id_performed",
+    "vehicle_id",
+    "trip_id_scheduled",
+    "route_id",
+    "route_type",
+    "shape_id",
+    "pattern_id",
+    "direction_id",
+    "operator_id",
+    "block_id",
+    "trip_start_stop_id",
+    "trip_end_stop_id",
+    "schedule_trip_start",
+    "schedule_trip_end",
+    "actual_trip_start",
+    "actual_trip_end",
+    "trip_type",
+    "schedule_relationship",
+    "ntd_mode",
+    "route_type_agency",
+]
+
+# Required CLEVER columns for this converter (excluding optional operator/stops).
+REQ_COLS: list[str] = [
+    "Vehicle",
+    "Route",
+    "Direction",
+    "Block",
+    "TripID",
+    "Trip Type",
+    "Scheduled Start Time",
+    "Scheduled Finish Time",
+    "Actual Start Time",
+    "Actual Finish Time",
+]
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def normalize_dt_series(series: pd.Series) -> pd.Series:
+    """Normalize datetime-like strings prior to pandas parsing."""
+    return (
+        series.astype("string")
+        .str.strip()
+        .str.replace(r"\s+", " ", regex=True)
+        .replace({"": pd.NA, "nan": pd.NA, "NaN": pd.NA, "N/A": pd.NA})
+    )
+
+
+def parse_route_id_from_route_text(route_series: pd.Series) -> pd.Series:
+    """Parse route_id from CLEVER 'Route' text left of '-' (trimmed)."""
+    route_text = route_series.astype("string").fillna("").str.strip()
+    left = route_text.str.split("-", n=1, expand=True)[0].str.strip()
+
+    # Prefer a 1–4 digit token when present; otherwise keep the left token.
+    digits = left.str.extract(r"^\s*([0-9]{1,4})\s*$")[0]
+    return digits.fillna(left).replace({"": pd.NA})
+
+
+def normalize_vehicle_id(vehicle_series: pd.Series) -> pd.Series:
+    """Normalize vehicle_id values (handle floats like '7785.0', trim whitespace)."""
+    raw = vehicle_series.astype("string").str.strip()
+    return (
+        raw.str.replace(r"\.0$", "", regex=True)
+        .str.replace(r"\s+", " ", regex=True)
+        .replace({"": pd.NA, "nan": pd.NA, "NaN": pd.NA, "<NA>": pd.NA})
+    )
+
+
+def stable_id(*parts: str) -> str:
+    """Short deterministic ID from multiple fields (sha1 truncated)."""
+    raw = "||".join(parts).encode("utf-8")
+    return hashlib.sha1(raw).hexdigest()[:16]
+
+
+def direction_id_from_text(series: pd.Series) -> pd.Series:
+    """Map Direction text to direction_id (nullable Int64)."""
+    s = series.astype("string").str.strip().str.upper()
+    mapped = s.map(DIRECTION_TEXT_TO_ID)
+    return mapped.astype("Int64")
+
+
+def dt_to_iso(series: pd.Series) -> pd.Series:
+    """Datetime -> ISO string (YYYY-MM-DDTHH:MM:SS); NaT -> NaN."""
+    return series.dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def summarize_trip_type_drops(
+    df: pd.DataFrame,
+    trip_type_col: str,
+    *,
+    keep_trip_type: str | None,
+) -> tuple[pd.DataFrame, dict[str, int]]:
+    """Optionally filter to a single trip type and return drop counts by type."""
+    if not keep_trip_type:
+        return df, {}
+
+    keep_norm = str(keep_trip_type).strip()
+    if not keep_norm:
+        return df, {}
+
+    s = df[trip_type_col].astype("string").str.strip()
+    mask_keep = s.eq(keep_norm)
+
+    dropped = s.loc[~mask_keep].fillna("<NA>")
+    dropped_counts = dropped.value_counts(dropna=False).to_dict()
+    return df.loc[mask_keep].copy(), {str(k): int(v) for k, v in dropped_counts.items()}
+
+
+def map_clever_trip_type_to_tides(series: pd.Series) -> pd.Series:
+    """Map CLEVER Trip Type labels to schema-conformant TIDES trip_type values."""
+    s = series.astype("string").str.strip()
+    upper = s.str.upper()
+
+    mapped = upper.map(CLEVER_TO_TIDES_TRIP_TYPE)
+
+    # If not mapped:
+    # - If original is missing -> NA
+    # - Else default to "Other not in service" (schema enum)
+    out = mapped.where(mapped.notna(), other="Other not in service")
+    out = out.where(s.notna(), other=pd.NA)
+    return out
+
+
+def choose_trip_id_performed(
+    service_date: pd.Series,
+    trip_id_scheduled: pd.Series,
+    vehicle_id: pd.Series,
+    best_start_dt: pd.Series,
+) -> tuple[pd.Series, int]:
+    """Use GTFS trip_id as trip_id_performed when unique within service_date; else hash.
+
+    Returns:
+        (trip_id_performed_series, n_dupe_rows)
+    """
+    base = pd.DataFrame(
+        {
+            "service_date": service_date.astype("string"),
+            "trip_id_scheduled": trip_id_scheduled.astype("string"),
+        }
+    )
+
+    dup = base.duplicated(keep=False) & trip_id_scheduled.notna()
+
+    best_start_str = best_start_dt.astype("datetime64[ns]").astype("string").fillna("")
+    hashed = pd.Series(
+        [
+            f"perf_{stable_id(str(sd), str(tid), str(veh), str(bs))}"
+            for sd, tid, veh, bs in zip(
+                service_date.fillna(""),
+                trip_id_scheduled.fillna(""),
+                vehicle_id.fillna(""),
+                best_start_str,
+                strict=True,
+            )
+        ],
+        index=service_date.index,
+        dtype="string",
+    )
+
+    perf = trip_id_scheduled.where(~dup, other=hashed)
+    return perf, int(dup.sum())
+
+
+# =============================================================================
+# CORE CONVERSION
+# =============================================================================
+
+
+def clever_to_tides(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert CLEVER Event Runtime Analysis export to TIDES trips_performed.csv."""
+    df = df.dropna(how="all").copy()
+
+    missing = [c for c in REQ_COLS if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required CLEVER columns: {missing}")
+
+    # Optional CLEVER Trip Type filter (keep only Revenue, etc.)
+    df, dropped_counts = summarize_trip_type_drops(
+        df,
+        "Trip Type",
+        keep_trip_type=KEEP_CLEVER_TRIP_TYPE,
+    )
+    if dropped_counts:
+        total_dropped = sum(dropped_counts.values())
+        logging.warning(
+            "Trip Type filter enabled (keep=%r): dropped %d rows of other types: %s",
+            KEEP_CLEVER_TRIP_TYPE,
+            total_dropped,
+            dropped_counts,
+        )
+
+    if df.empty:
+        logging.warning("No rows remain after Trip Type filtering.")
+        return pd.DataFrame(columns=TIDES_COLS)
+
+    # Parse datetimes robustly
+    sched_start_dt = pd.to_datetime(
+        normalize_dt_series(df["Scheduled Start Time"]),
+        errors="coerce",
+        infer_datetime_format=True,
+    )
+    sched_end_dt = pd.to_datetime(
+        normalize_dt_series(df["Scheduled Finish Time"]),
+        errors="coerce",
+        infer_datetime_format=True,
+    )
+    actual_start_dt = pd.to_datetime(
+        normalize_dt_series(df["Actual Start Time"]),
+        errors="coerce",
+        infer_datetime_format=True,
+    )
+    actual_end_dt = pd.to_datetime(
+        normalize_dt_series(df["Actual Finish Time"]),
+        errors="coerce",
+        infer_datetime_format=True,
+    )
+
+    # Date the trip: prefer scheduled start; fallback to actual start
+    best_start_dt = sched_start_dt.where(sched_start_dt.notna(), actual_start_dt)
+
+    # Drop rows that cannot be dated at all
+    mask_undated = best_start_dt.isna()
+    if mask_undated.any():
+        n_drop = int(mask_undated.sum())
+        logging.warning(
+            "Dropping %d rows: neither Scheduled Start Time nor Actual Start Time is parseable.",
+            n_drop,
+        )
+        df = df.loc[~mask_undated].copy()
+        sched_start_dt = sched_start_dt.loc[~mask_undated]
+        sched_end_dt = sched_end_dt.loc[~mask_undated]
+        actual_start_dt = actual_start_dt.loc[~mask_undated]
+        actual_end_dt = actual_end_dt.loc[~mask_undated]
+        best_start_dt = best_start_dt.loc[~mask_undated]
+
+    # vehicle_id is required by schema
+    vehicle_id = normalize_vehicle_id(df["Vehicle"])
+    mask_no_vehicle = vehicle_id.isna()
+    if mask_no_vehicle.any():
+        n_drop = int(mask_no_vehicle.sum())
+        logging.warning("Dropping %d rows: missing Vehicle / vehicle_id.", n_drop)
+        df = df.loc[~mask_no_vehicle].copy()
+        vehicle_id = vehicle_id.loc[~mask_no_vehicle]
+        sched_start_dt = sched_start_dt.loc[~mask_no_vehicle]
+        sched_end_dt = sched_end_dt.loc[~mask_no_vehicle]
+        actual_start_dt = actual_start_dt.loc[~mask_no_vehicle]
+        actual_end_dt = actual_end_dt.loc[~mask_no_vehicle]
+        best_start_dt = best_start_dt.loc[~mask_no_vehicle]
+
+    if df.empty:
+        logging.warning("No rows remain after dropping missing vehicle_id.")
+        return pd.DataFrame(columns=TIDES_COLS)
+
+    out = pd.DataFrame(index=df.index)
+
+    # Required schema fields
+    out["service_date"] = best_start_dt.dt.date.astype("string")
+    out["vehicle_id"] = vehicle_id
+
+    # GTFS trip_id from CLEVER TripID (per your statement)
+    out["trip_id_scheduled"] = df["TripID"].astype("string").str.strip().replace({"": pd.NA})
+
+    # Per schema: trip_id_performed must be unique within service_date
+    out["trip_id_performed"], n_dupe_rows = choose_trip_id_performed(
+        out["service_date"],
+        out["trip_id_scheduled"],
+        out["vehicle_id"],
+        best_start_dt,
+    )
+    if n_dupe_rows:
+        logging.warning(
+            "trip_id_scheduled duplicates within service_date for %d rows; "
+            "used hashed trip_id_performed for those rows.",
+            n_dupe_rows,
+        )
+
+    # Optional schema fields we can populate
+    out["route_id"] = parse_route_id_from_route_text(df["Route"])
+    out["direction_id"] = direction_id_from_text(df["Direction"])
+    out["block_id"] = df["Block"].astype("string").str.strip().replace({"": pd.NA})
+
+    if OPERATOR_COL in df.columns:
+        out["operator_id"] = df[OPERATOR_COL].astype("string").str.strip().replace({"": pd.NA})
+    else:
+        out["operator_id"] = pd.NA
+
+    # Stops (text IDs are fine)
+    if TRIP_START_STOP_COL and TRIP_START_STOP_COL in df.columns:
+        out["trip_start_stop_id"] = (
+            df[TRIP_START_STOP_COL].astype("string").str.strip().replace({"": pd.NA})
+        )
+    else:
+        out["trip_start_stop_id"] = pd.NA
+
+    if TRIP_END_STOP_COL and TRIP_END_STOP_COL in df.columns:
+        out["trip_end_stop_id"] = (
+            df[TRIP_END_STOP_COL].astype("string").str.strip().replace({"": pd.NA})
+        )
+    else:
+        out["trip_end_stop_id"] = pd.NA
+
+    # Times (allowed to be missing)
+    out["schedule_trip_start"] = dt_to_iso(sched_start_dt)
+    out["schedule_trip_end"] = dt_to_iso(sched_end_dt)
+    out["actual_trip_start"] = dt_to_iso(actual_start_dt)
+    out["actual_trip_end"] = dt_to_iso(actual_end_dt)
+
+    # trip_type must match schema enum; map from CLEVER Trip Type
+    out["trip_type"] = map_clever_trip_type_to_tides(df["Trip Type"])
+
+    # Schedule relationship enum
+    out["schedule_relationship"] = "Scheduled"
+
+    # Fields not available from this export (leave blank)
+    out["route_type"] = pd.NA
+    out["shape_id"] = pd.NA
+    out["pattern_id"] = pd.NA
+    out["ntd_mode"] = pd.NA
+    out["route_type_agency"] = pd.NA
+
+    # Final order (schema-defined columns; extras left out)
+    out = out.reindex(columns=TIDES_COLS)
+
+    # Log missing actual times (expected; do not drop)
+    n_missing_actual_start = int(out["actual_trip_start"].isna().sum())
+    n_missing_actual_end = int(out["actual_trip_end"].isna().sum())
+    if n_missing_actual_start or n_missing_actual_end:
+        logging.warning(
+            "Kept rows with missing actual times: %d missing actual start, %d missing actual end.",
+            n_missing_actual_start,
+            n_missing_actual_end,
+        )
+
+    # Required field checks per schema (service_date, trip_id_performed, vehicle_id)
+    for req in ("service_date", "trip_id_performed", "vehicle_id"):
+        if out[req].isna().any():
+            bad = out.loc[out[req].isna()].head(10)
+            raise ValueError(f"Nulls found in required column '{req}'. Sample:\n{bad}")
+
+    return out
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+
+def main() -> None:
+    """Run the CLEVER → TIDES trips_performed conversion pipeline."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    df = pd.read_csv(INPUT_CSV, low_memory=False)
+    logging.info("Read %d rows, %d columns", len(df), df.shape[1])
+
+    out = clever_to_tides(df)
+
+    OUTPUT_CSV.parent.mkdir(parents=True, exist_ok=True)
+    out.to_csv(OUTPUT_CSV, index=False)
+    logging.info("Wrote %d rows -> %s", len(out), OUTPUT_CSV)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add `clever_to_tides_stop_visits.py` and `clever_to_tides_trips_performed.py` to `scripts/operations_tools/`. These scripts allow converting CLEVER data exports into TIDES-compliant formats, handling common data issues and schema requirements.

---
*PR created automatically by Jules for task [9652985388486586510](https://jules.google.com/task/9652985388486586510) started by @zekrowm*