### PR TITLE
fix: correct test data mapping and coverage path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           PYTHONPATH: "."
         run: |
-          pytest -q --cov=helpers --cov-report=term-missing:skip-covered
+          pytest -q --cov=utils --cov-report=term-missing:skip-covered

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,10 @@ Participation is welcome from anyone, whether you’re new to coding, an experie
   - Prefer inline variable configuration over `argparse`.
 - Use intuitive success messages at the end of script execution.
   - e.g., `print("Script completed successfully.")` or equivalent `logging` call.
-- Do **not import** functions from the shared `helpers/` directory at runtime.
+- Do **not import** functions from the shared `utils/` directory at runtime.
   - Instead, **copy the relevant helper functions** into your script.
   - This keeps each script self-contained and easier for beginners to understand, run, and modify.
-- The `helpers/` directory holds the **canonical version** of shared functions. Any differences between a script’s local copy and the canonical version will be flagged in CI.
+- The `utils/` directory holds the **canonical version** of shared functions. Any differences between a script’s local copy and the canonical version will be flagged in CI.
 
 ## ⚙️ Runtime Behavior
 
@@ -60,14 +60,14 @@ New or modified scripts under `scripts/` **must be manually tested** before open
 
 ### 🧩 Unit Tests for Helper Functions
 
-If you add or significantly modify a function in the `helpers/` directory:
+If you add or significantly modify a function in the `utils/` directory:
 
 - Write a **unit test** that exercises its normal behavior and at least one error condition.
 - Save new tests under `tests/unit/` following the naming pattern `test_<module>.py`.
 - Use small, synthetic input data—do **not** rely on external files or network access.
 - Tests should run quickly (<1 s each) and be deterministic.
 - These tests protect against silent failures caused by future changes to dependencies (e.g., pandas, geopandas).
-- A pull request adding or modifying helpers **without** a corresponding test may be asked to add one before review.
+- A pull request adding or modifying utils **without** a corresponding test may be asked to add one before review.
 
 ## 🧼 Code Style
 
@@ -89,9 +89,9 @@ Most formatting issues (indentation, line length, spacing) are auto-corrected by
 
 - Add new scripts to the appropriate subfolder within `scripts/`, based on function (e.g., `ridership_tools/`, `gtfs_exports/`).
 - If you create a helper that’s reused across multiple scripts:
-  - Add the canonical version to the appropriate file under `helpers/`.
+  - Add the canonical version to the appropriate file under `utils/`.
   - Then copy that helper into any script that uses it.
-- Do **not** import functions from one script into another or from `helpers/` at runtime.
+- Do **not** import functions from one script into another or from `utils/` at runtime.
 
 ## 🌳 GitHub Contribution Workflow
 

--- a/tests/test_otp_monthly_by_timepoint_order.py
+++ b/tests/test_otp_monthly_by_timepoint_order.py
@@ -18,6 +18,9 @@ def tides_input_csv(tmp_path: Path) -> Path:
 
     # Add simulated joined columns
     # Pattern is PAT_30_WB or PAT_30_EB.
+    df["pattern_id"] = df["pattern_id"].map(
+        {"shp-101-01": "PAT_30_WB", "shp-101-51": "PAT_30_EB"}
+    )
     df["route_id"] = "30"
     df["direction_id"] = df["pattern_id"].apply(lambda x: "0" if "WB" in x else "1")
 

--- a/tests/test_otp_monthly_by_timepoint_order.py
+++ b/tests/test_otp_monthly_by_timepoint_order.py
@@ -18,9 +18,7 @@ def tides_input_csv(tmp_path: Path) -> Path:
 
     # Add simulated joined columns
     # Pattern is PAT_30_WB or PAT_30_EB.
-    df["pattern_id"] = df["pattern_id"].map(
-        {"shp-101-01": "PAT_30_WB", "shp-101-51": "PAT_30_EB"}
-    )
+    df["pattern_id"] = df["pattern_id"].map({"shp-101-01": "PAT_30_WB", "shp-101-51": "PAT_30_EB"})
     df["route_id"] = "30"
     df["direction_id"] = df["pattern_id"].apply(lambda x: "0" if "WB" in x else "1")
 


### PR DESCRIPTION
- **tests/test_otp_monthly_by_timepoint_order.py**: Explicitly map `pattern_id` values from the fixture (`shp-101-01`, `shp-101-51`) to the values expected by the test (`PAT_30_WB`, `PAT_30_EB`). This fixes the failure in `test_tides_data_processing` where the direction logic was incorrectly inferring direction from the raw pattern ID.
- **.github/workflows/tests.yml**: Update the `pytest` command to use `--cov=utils` instead of `--cov=helpers`. This resolves the "Module not imported" warning in coverage reports, reflecting the recent directory rename.
- **CONTRIBUTING.md**: Update all references from `helpers/` to `utils/` to ensure documentation matches the current project structure.

---
*PR created automatically by Jules for task [3991709421481739900](https://jules.google.com/task/3991709421481739900) started by @zekrowm*