### PR TITLE
chore: downgrade all ty rules to warning to unblock CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,20 +39,20 @@ exclude = ["**/*arcpy*"]
 python-version = "3.12"
 
 [tool.ty.rules]
-unsupported-operator = "error"
-invalid-return-type = "error"
+unsupported-operator = "warn"
+invalid-return-type = "warn"
 unresolved-import = "warn"
-invalid-assignment = "error"
+invalid-assignment = "warn"
 invalid-argument-type = "warn"
-not-subscriptable = "error"
-not-iterable = "error"
+not-subscriptable = "warn"
+not-iterable = "warn"
 no-matching-overload = "warn"
-invalid-parameter-default = "error"
-possibly-missing-attribute = "error"
-redundant-cast = "error"
-unresolved-reference = "error"
-unresolved-attribute = "error"
-unresolved-global = "error"
+invalid-parameter-default = "warn"
+possibly-missing-attribute = "warn"
+redundant-cast = "warn"
+unresolved-reference = "warn"
+unresolved-attribute = "warn"
+unresolved-global = "warn"
 
 # ================================================================
 # COMMIT MESSAGE LINTING


### PR DESCRIPTION
This PR downgrades all strict ty configuration rules in pyproject.toml from error to warn.

Currently, the PR gate check is failing with over 3,000 lines of type errors, primarily unresolved-attribute, which is blocking development. By relaxing these rules to warnings, we can immediately unblock the CI pipeline while retaining visibility into the issues. The team's strategy is to use this stable baseline to incrementally re-enable strict checking for individual rules in future PRs, addressing violations in manageable batches rather than all at once. Verified that ty now exits successfully with only warnings.