### PR TITLE
chore: Add PR title linting for Conventional Commits

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,25 @@
+name: "Lint PR"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: python dev_tools/lint_pr.py "$TITLE"

--- a/dev_tools/lint_pr.py
+++ b/dev_tools/lint_pr.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Lint a Pull Request title to ensure it follows Conventional Commits.
+
+Usage:
+    python lint_pr.py "<PR_TITLE>"
+
+The title must follow the format:
+    <type>(<scope>): <Description>
+
+Where:
+    <type> is one of: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+    <scope> is optional, lowercase alphanumeric with hyphens
+    <Description> starts with a capital letter
+"""
+import re
+import sys
+
+# Regex pattern for Conventional Commits with capitalized description
+# Group 1: Type
+# Group 2: Optional Scope (including parens)
+# Match: ": " followed by Capital letter and then anything
+PATTERN = (
+    r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)"
+    r"(\([a-z0-9-]+\))?: [A-Z].+$"
+)
+
+
+def main() -> None:
+    """Validate the PR title from command-line arguments."""
+    if len(sys.argv) < 2:
+        print("Error: No PR title provided.")
+        sys.exit(1)
+
+    title = sys.argv[1]
+    if not re.match(PATTERN, title):
+        print(f"Error: PR title '{title}' does not follow Conventional Commits.")
+        print("Format: <type>(<scope>): <Description>")
+        print("  - Types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test")
+        print("  - Scope: Optional, lowercase alphanumeric with hyphens (e.g., (scope))")
+        print("  - Description: Must start with a capital letter")
+        sys.exit(1)
+
+    print("Success: PR title is valid.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev_tools/lint_pr.py
+++ b/dev_tools/lint_pr.py
@@ -12,6 +12,7 @@ Where:
     <scope> is optional, lowercase alphanumeric with hyphens
     <Description> starts with a capital letter
 """
+
 import re
 import sys
 


### PR DESCRIPTION
Adds a new `dev_tools/lint_pr.py` script and a `.github/workflows/lint-pr.yml` workflow to enforce Conventional Commits on PR titles. The check requires standard types and a capitalized description.

---
*PR created automatically by Jules for task [17329721369190951252](https://jules.google.com/task/17329721369190951252) started by @zekrowm*