### PR TITLE
chore: change PR title convention to lowercase description

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,13 @@ Participation is welcome from anyone, whether you’re new to coding, an experie
 ## 🧪 Testing & Review
 
 - All commits and **Pull Request titles** must use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for clear project history.
+
+**PR title format:** `<type>(<optional-scope>): <description>`
+- Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
+- Scope (optional): lowercase letters, digits, and hyphens only
+- Description: starts with a lowercase letter
+
+Example: `feat(gtfs): add stop spacing validator`
 - All pull requests are automatically tested for:
   - Style and formatting using `ruff`.
   - Static typing using [`ty`](https://github.com/astral-sh/ty).

--- a/dev_tools/lint_pr.py
+++ b/dev_tools/lint_pr.py
@@ -10,19 +10,15 @@ The title must follow the format:
 Where:
     <type> is one of: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
     <scope> is optional, lowercase alphanumeric with hyphens
-    <Description> starts with a capital letter
+    <description> starts with a lowercase letter
 """
 
 import re
 import sys
 
-# Regex pattern for Conventional Commits with capitalized description
-# Group 1: Type
-# Group 2: Optional Scope (including parens)
-# Match: ": " followed by Capital letter and then anything
 PATTERN = (
     r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)"
-    r"(\([a-z0-9-]+\))?: [A-Z].+$"
+    r"(\([a-z0-9-]+\))?: [a-z].+$"
 )
 
 
@@ -38,7 +34,7 @@ def main() -> None:
         print("Format: <type>(<scope>): <Description>")
         print("  - Types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test")
         print("  - Scope: Optional, lowercase alphanumeric with hyphens (e.g., (scope))")
-        print("  - Description: Must start with a capital letter")
+        print("  - Description: Must start with a lowercase letter")
         sys.exit(1)
 
     print("Success: PR title is valid.")


### PR DESCRIPTION
## Summary
Updated the PR title linting rules and documentation to require descriptions starting with a lowercase letter instead of uppercase, aligning with a more modern conventional commits style.

## Changes Made
- **Updated regex pattern** in `dev_tools/lint_pr.py`: Changed the description validation from `[A-Z]` (capital letter) to `[a-z]` (lowercase letter)
- **Updated validation messages**: Modified error and help messages to reflect the new lowercase requirement
- **Enhanced CONTRIBUTING.md**: Added detailed PR title format documentation with:
  - Clear format specification: `<type>(<optional-scope>): <description>`
  - List of allowed commit types
  - Scope requirements (lowercase letters, digits, hyphens)
  - Description requirement (lowercase letter start)
  - Concrete example: `feat(gtfs): add stop spacing validator`

## Implementation Details
The change is straightforward - the regex pattern now expects lowercase letters at the start of the description, making the convention more consistent with modern commit message practices that favor lowercase descriptions for consistency and readability.

https://claude.ai/code/session_01RgtNyZmRZozo6G4CbQ6RSL