### PR TITLE
docs: add claude code guidelines and pr conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# Instructions for Claude Code
+
+## PR titles (REQUIRED — enforced in CI)
+Every PR title MUST follow Conventional Commits with a lowercase
+description. This is checked by `dev_tools/lint_pr.py` and will
+fail CI otherwise.
+
+Format: `<type>(<optional-scope>): <description>`
+
+- Allowed types: build, chore, ci, docs, feat, fix, perf,
+  refactor, revert, style, test
+- Scope (optional): lowercase letters, digits, hyphens
+- Description: starts with a lowercase letter, no period at end
+
+Good examples:
+  feat(gtfs): add stop spacing validator
+  fix(utils): handle empty shapes.txt gracefully
+  docs: clarify pr title convention
+
+Bad examples (will fail CI):
+  Change PR title convention to lowercase description   (no type)
+  feat: Add stop spacing validator                      (capitalized)
+  feat(GTFS): add stop spacing validator                (uppercase scope)
+
+Before opening a PR, double-check the title matches this format.
+
+## Commit messages
+Follow the same Conventional Commits format for commits. Not
+enforced in CI, but kept consistent for project history.
+
+## Other conventions
+See CONTRIBUTING.md for code style, testing policy, and the
+file-organization rules — especially the "copy helpers from
+utils/, don't import them at runtime" rule.


### PR DESCRIPTION
## Summary
Added a new `CLAUDE.md` file documenting code guidelines and pull request conventions for the project, with a focus on enforcing Conventional Commits format for PR titles.

## Changes
- Created `CLAUDE.md` with comprehensive guidelines including:
  - **PR title requirements**: Enforced Conventional Commits format (`<type>(<optional-scope>): <description>`) with lowercase descriptions, validated by `dev_tools/lint_pr.py`
  - **Allowed commit types**: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
  - **Scope rules**: Optional, lowercase letters/digits/hyphens only
  - **Description rules**: Must start with lowercase letter, no period at end
  - **Examples**: Provided both good and bad PR title examples to clarify expectations
  - **Commit message guidance**: Recommends same Conventional Commits format for consistency (not CI-enforced)
  - **Cross-reference**: Points to `CONTRIBUTING.md` for additional code style and testing policies

## Notable Details
This document serves as a quick reference guide for contributors, particularly for Claude-assisted development, ensuring consistent PR formatting and making CI validation expectations clear upfront.

https://claude.ai/code/session_01N3vYRcdWcryAtm4diEaZvJ