### PR TITLE
ci(tests): install real deps and remove sys.modules mock workarounds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,13 +21,14 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
-      - name: Install tooling
+      - name: Install dependencies
         run: |
           python -m pip install -U pip
-          pip install pytest pytest-cov pandas
+          pip install -r requirements.txt
 
       - name: Run tests with coverage
         env:
           PYTHONPATH: "."
+          MPLBACKEND: "Agg"
         run: |
           pytest -q --cov=utils --cov-report=term-missing:skip-covered

--- a/tests/test_data_request_by_stop_processor.py
+++ b/tests/test_data_request_by_stop_processor.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -8,22 +8,6 @@ import pytest
 # Add the script directory to sys.path to allow importing the module
 script_dir = Path("scripts/ridership_tools").resolve()
 sys.path.append(str(script_dir))
-
-# Mock openpyxl if it's not installed, as it is used at module level
-# We do this before importing the target module
-try:
-    import openpyxl  # noqa: F401
-except ImportError:
-    # Create a dummy module
-    mock_openpyxl = MagicMock()
-    # We need to mock specific submodules/attributes accessed at top-level
-    mock_openpyxl.styles = MagicMock()
-    mock_openpyxl.utils = MagicMock()
-
-    # Inject into sys.modules
-    sys.modules["openpyxl"] = mock_openpyxl
-    sys.modules["openpyxl.styles"] = mock_openpyxl.styles
-    sys.modules["openpyxl.utils"] = mock_openpyxl.utils
 
 import data_request_by_stop_processor as target  # noqa: E402
 

--- a/tests/test_load_factor_monitor.py
+++ b/tests/test_load_factor_monitor.py
@@ -106,8 +106,7 @@ def test_integration_exports(input_df, tmp_path, monkeypatch) -> None:
     fake_output_xlsx = tmp_path / "processed_stats.xlsx"
     monkeypatch.setattr(load_factor_monitor, "OUTPUT_FILE", str(fake_output_xlsx))
 
-    # Mock export functions to avoid 'openpyxl' import errors in CI
-    # We only verify that the logic flow reaches these functions
+    # Mock export functions for test isolation; we verify logic flow, not file I/O
     monkeypatch.setattr(load_factor_monitor, "export_to_excel", lambda df, path: None)
     monkeypatch.setattr(load_factor_monitor, "create_route_workbooks", lambda df: None)
 

--- a/tests/test_ntd_route_trends.py
+++ b/tests/test_ntd_route_trends.py
@@ -1,30 +1,9 @@
-import sys
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
-
-# -- MOCK MATPLOTLIB BEFORE IMPORTING SCRIPT --
-# This prevents ModuleNotFoundError if matplotlib is not installed in the environment.
-try:
-    import matplotlib
-
-    # Use Agg backend if real matplotlib is present
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt  # noqa: F401
-
-    HAS_MATPLOTLIB = True
-except ImportError:
-    # If not present, install a mock into sys.modules
-    mock_mpl = MagicMock()
-    mock_plt = MagicMock()
-    # Mock specific submodules used by ntd_route_trends.py
-    sys.modules["matplotlib"] = mock_mpl
-    sys.modules["matplotlib.pyplot"] = mock_plt
-    sys.modules["matplotlib.dates"] = MagicMock()
-    HAS_MATPLOTLIB = False
 
 # Import the script to be tested
 from scripts.ridership_tools import ntd_route_trends
@@ -141,11 +120,9 @@ def test_ntd_route_trends_integration(input_df, tmp_path) -> None:
         file_path = route_101_dir / filename
         assert file_path.exists(), f"Expected output file {filename} missing for route 101"
 
-    # Check for plots only if we had real matplotlib
-    if HAS_MATPLOTLIB:
-        for filename in ["plots/monthly_totals.png", "plots/daily_averages.png"]:
-            file_path = route_101_dir / filename
-            assert file_path.exists(), f"Expected plot file {filename} missing for route 101"
+    for filename in ["plots/monthly_totals.png", "plots/daily_averages.png"]:
+        file_path = route_101_dir / filename
+        assert file_path.exists(), f"Expected plot file {filename} missing for route 101"
 
     # 4. Verify content of monthly_long.csv for Route 101
     df_long = pd.read_csv(route_101_dir / "monthly_long.csv")

--- a/tests/test_otp_monthly_trends_export.py
+++ b/tests/test_otp_monthly_trends_export.py
@@ -1,23 +1,9 @@
 import re
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
-
-try:
-    import matplotlib
-
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt  # noqa: F401
-
-    HAS_MATPLOTLIB = True
-except ImportError:
-    mock_mpl = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock
-    sys.modules["matplotlib"] = mock_mpl()
-    sys.modules["matplotlib.pyplot"] = mock_mpl()
-    HAS_MATPLOTLIB = False
 
 from scripts.operations_tools.otp_monthly_trends_export import (
     _normalize_dow,
@@ -390,7 +376,6 @@ def _make_plt_mock() -> MagicMock:
     return mock_plt
 
 
-@pytest.mark.skipif(not HAS_MATPLOTLIB, reason="matplotlib not installed")
 def test_plot_series_for_groups_creates_pngs(processed_df: pd.DataFrame, tmp_path: Path) -> None:
     mock_plt = _make_plt_mock()
     with patch(_MODULE_PLT, mock_plt):
@@ -399,7 +384,6 @@ def test_plot_series_for_groups_creates_pngs(processed_df: pd.DataFrame, tmp_pat
     assert mock_plt.savefig.call_count > 0
 
 
-@pytest.mark.skipif(not HAS_MATPLOTLIB, reason="matplotlib not installed")
 def test_plot_series_for_groups_weekday_saturday_sunday(
     processed_df: pd.DataFrame, tmp_path: Path
 ) -> None:

--- a/tests/test_trip_event_runtime_diagnostics.py
+++ b/tests/test_trip_event_runtime_diagnostics.py
@@ -8,13 +8,6 @@ import pandas as pd
 script_dir = Path("scripts/operations_tools").resolve()
 sys.path.append(str(script_dir))
 
-from unittest.mock import MagicMock  # noqa: E402
-
-# Mock visualization libraries to allow tests to run in environments without them
-sys.modules["matplotlib"] = MagicMock()
-sys.modules["matplotlib.pyplot"] = MagicMock()
-sys.modules["seaborn"] = MagicMock()
-
 import trip_event_runtime_diagnostics as target  # noqa: E402
 
 FIXTURE_PATH = Path("tests/fixtures/trips_performed.csv")


### PR DESCRIPTION
## Summary
This PR removes conditional mocking of optional dependencies (matplotlib, openpyxl, seaborn) from test files and instead ensures these dependencies are installed in the test environment via `requirements.txt`.

## Key Changes
- **Removed matplotlib mocking** from `test_ntd_route_trends.py`, `test_otp_monthly_trends_export.py`, and `test_trip_event_runtime_diagnostics.py`
  - Eliminated `HAS_MATPLOTLIB` flag and conditional test skipping
  - Removed sys.modules injection for matplotlib and related modules
  
- **Removed openpyxl mocking** from `test_data_request_by_stop_processor.py`
  - Eliminated sys.modules injection for openpyxl and its submodules
  
- **Removed seaborn mocking** from `test_trip_event_runtime_diagnostics.py`
  - Eliminated sys.modules injection for seaborn
  
- **Updated CI workflow** (`.github/workflows/tests.yml`)
  - Changed dependency installation from manual pip commands to `pip install -r requirements.txt`
  - Added `MPLBACKEND: "Agg"` environment variable for matplotlib in headless CI environments
  
- **Simplified test assertions**
  - Removed conditional checks for plot file existence based on `HAS_MATPLOTLIB`
  - Removed `@pytest.mark.skipif` decorators that depended on optional dependencies
  - Updated comments to reflect simplified test isolation approach

## Implementation Details
The changes assume that all required dependencies are now properly declared in `requirements.txt` and will be installed before tests run. The matplotlib backend is explicitly set to "Agg" in the CI environment to handle headless execution without requiring X11 or display servers.

https://claude.ai/code/session_01NVgcBZ3R6CPjMRnvgMhXPr