### PR TITLE
chore(deps): split dev tooling into requirements-dev.txt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Run tests with coverage
         env:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,25 @@
+
+# =============================================================================
+# Dev / Test tooling — not needed to run the project
+# =============================================================================
+# Install after requirements.txt:
+#   pip install -r requirements.txt -r requirements-dev.txt
+# -----------------------------------------------------------------------------
+
+# Testing
+faker==25.8.0                # Fake data generation for tests
+pytest==8.3.5                # Unit testing framework
+pytest-cov                   # Test coverage reporting
+
+# Linting & formatting
+ruff                         # Linting & formatting
+
+# Type checking
+ty                           # Non-blocking type checks
+
+# ------------- Typing stubs (temporary) -------------------------------------
+pandas-stubs==2.2.*
+types-openpyxl>=3.1,<5
+types-networkx>=3.4,<4
+#types-faker>=25,<26
+#types-rapidfuzz>=3.11,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 
 # =============================================================================
-# Open-Source / Non-ArcGIS Stack — and CI/dev tooling
+# Open-Source / Non-ArcGIS Stack — runtime dependencies
 # =============================================================================
 # Use this file when running outside ArcGIS Pro (home computer, CI, etc.).
 # For the ArcGIS Pro environment, see requirements_arcpro.txt instead.
+# For dev/test tooling (pytest, ruff, ty, stubs), see requirements-dev.txt.
 # Note: packages shared with the ArcPro stack are listed in both files.
 # -----------------------------------------------------------------------------
 
@@ -33,19 +34,3 @@ rapidfuzz==3.13.0            # Fast fuzzy string matching
 
 # Optimization
 pulp==2.9.0                  # Linear programming solver interface
-
-# Development Tools
-faker==25.8.0                # For generating fake data
-pytest==8.3.5                # Unit testing framework
-
-# CI/dev tooling
-pytest-cov                   # Test coverage reporting
-ruff                         # Linting & formatting
-ty                           # Non-blocking type checks
-
-# ------------- Typing stubs (temporary) -------------------------------------
-pandas-stubs==2.2.*
-types-openpyxl>=3.1,<5
-types-networkx>=3.4,<4
-#types-faker>=25,<26
-#types-rapidfuzz>=3.11,<4


### PR DESCRIPTION
## Summary
Reorganized project dependencies by separating development and testing tools into a dedicated `requirements-dev.txt` file, keeping `requirements.txt` focused on runtime dependencies only.

## Changes Made
- **Created `requirements-dev.txt`**: New file containing all development, testing, and CI tooling dependencies:
  - Testing: faker, pytest, pytest-cov
  - Linting & formatting: ruff
  - Type checking: ty
  - Typing stubs: pandas-stubs, types-openpyxl, types-networkx

- **Updated `requirements.txt`**: 
  - Removed all dev/test tooling packages (faker, pytest, pytest-cov, ruff, ty, and typing stubs)
  - Updated header comment to clarify this file contains runtime dependencies only
  - Added reference to `requirements-dev.txt` for developers
  - Kept all production dependencies intact

## Installation
Users can now install dependencies with:
- Runtime only: `pip install -r requirements.txt`
- Runtime + dev tools: `pip install -r requirements.txt -r requirements-dev.txt`

This improves dependency management by clearly separating production requirements from development tooling, reducing unnecessary dependencies in production environments.

https://claude.ai/code/session_0118tKkwCJNTtE3JxZoq1n72