### PR TITLE
feat(facilities-tools): warn on default filepaths and log completion

### DIFF
--- a/scripts/facilities_tools/bay_usage_analyzer.py
+++ b/scripts/facilities_tools/bay_usage_analyzer.py
@@ -367,6 +367,22 @@ def gather_block_spreadsheets(block_folder: str) -> DataFrame:
     return df_combined
 
 
+_PLACEHOLDER_MARKERS: Tuple[str, ...] = (
+    "path\\to\\your",
+    "your\\file\\path",
+    "your\\folder\\path",
+    "path/to/your",
+    "your/file/path",
+    "your/folder/path",
+)
+
+
+def _is_placeholder_path(p: str) -> bool:
+    """Return True if *p* still points at a default placeholder location."""
+    s = str(p).lower()
+    return any(marker in s for marker in _PLACEHOLDER_MARKERS)
+
+
 def run_step2_conflict_detection() -> None:
     """Execute the full Step 2 conflict-detection workflow.
 
@@ -385,6 +401,21 @@ def run_step2_conflict_detection() -> None:
         If required columns are missing from the input spreadsheets.
     """
     logging.info("=== Step 2: Conflict detection and per-cluster output (multi-bay) ===")
+
+    placeholders = {
+        "BLOCK_OUTPUT_FOLDER": BLOCK_OUTPUT_FOLDER,
+        "CLUSTER_CONFLICT_OUTPUT_FOLDER": CLUSTER_CONFLICT_OUTPUT_FOLDER,
+    }
+    unset = [name for name, p in placeholders.items() if _is_placeholder_path(p)]
+    if unset:
+        logging.warning(
+            "Default placeholder filepaths detected for: %s. "
+            "Update the CONFIGURATION section of this script with real paths "
+            "before running. Exiting without processing.",
+            ", ".join(unset),
+        )
+        return
+
     os.makedirs(CLUSTER_CONFLICT_OUTPUT_FOLDER, exist_ok=True)
 
     # 1) Gather Step 1 data
@@ -491,6 +522,7 @@ def run_step2_conflict_detection() -> None:
     logging.info("\nDistinct cluster-conflict points: %d", len(cluster_conflicts))
     logging.info("Distinct stop-conflict points: %d", len(stop_conflicts))
     logging.info("Step 2 complete.")
+    logging.info("bay_usage_analyzer.py completed successfully.")
 
 
 # ==================================================================================================

--- a/scripts/facilities_tools/flag_stop_upgrades.py
+++ b/scripts/facilities_tools/flag_stop_upgrades.py
@@ -38,7 +38,6 @@ RIDERSHIP_XLSX: Path = Path(r"Your\File\Path\To\STOP_USAGE_(BY_STOP_ID).xlsx")
 RIDERSHIP_SHEET: int | str = 0
 # Output folder (Excel + TXT will be written here)
 OUTPUT_FOLDER: Path = Path(r"Your\Folder\Path\To\Output")
-OUTPUT_FOLDER.mkdir(parents=True, exist_ok=True)
 
 # Fields in ridership workbook
 RIDERSHIP_FIELD: str = "XBOARDINGS"
@@ -218,6 +217,22 @@ def _write_txt_log(processed_df: pd.DataFrame, flag_cols: List[str], out_path: P
 # =============================================================================
 
 
+_PLACEHOLDER_MARKERS: Tuple[str, ...] = (
+    "your\\file\\path",
+    "your\\folder\\path",
+    "path\\to\\your",
+    "your/file/path",
+    "your/folder/path",
+    "path/to/your",
+)
+
+
+def _is_placeholder_path(p: Path) -> bool:
+    """Return True if *p* still points at a default placeholder location."""
+    s = str(p).lower()
+    return any(marker in s for marker in _PLACEHOLDER_MARKERS)
+
+
 def main() -> None:
     """Run the ETL pipeline and produce both Excel and text outputs."""
     logging.basicConfig(
@@ -225,6 +240,24 @@ def main() -> None:
         format="%(asctime)s | %(levelname)s | %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
+
+    placeholders = {
+        "RIDERSHIP_XLSX": RIDERSHIP_XLSX,
+        "AMENITIES_XLSX": AMENITIES_XLSX,
+        "OUTPUT_FOLDER": OUTPUT_FOLDER,
+    }
+    unset = [name for name, p in placeholders.items() if _is_placeholder_path(p)]
+    if unset:
+        logging.warning(
+            "Default placeholder filepaths detected for: %s. "
+            "Update the CONFIGURATION section of this script with real paths "
+            "before running. Exiting without processing.",
+            ", ".join(unset),
+        )
+        return
+
+    OUTPUT_FOLDER.mkdir(parents=True, exist_ok=True)
+
     # 1–2. LOAD SOURCE FILES
     df_raw = _load_ridership_data(RIDERSHIP_XLSX, RIDERSHIP_SHEET)
     df_amen = _load_amenity_data(AMENITIES_XLSX, AMENITIES_SHEET)
@@ -255,6 +288,8 @@ def main() -> None:
     if need_agg:
         dup_ct = df_raw.shape[0] - df_processed.shape[0]
         logging.info("  (Aggregated %d duplicate STOP_ID rows.)", dup_ct)
+
+    logging.info("flag_stop_upgrades.py completed successfully.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Added validation logic to both `flag_stop_upgrades.py` and `bay_usage_analyzer.py` to detect when configuration paths are still set to placeholder values and prevent the scripts from running until they are properly configured.

## Key Changes

- **Placeholder detection utility**: Added `_is_placeholder_path()` function and `_PLACEHOLDER_MARKERS` tuple to both scripts to identify common placeholder path patterns (e.g., "your\file\path", "path/to/your")

- **Configuration validation in main entry points**: 
  - `flag_stop_upgrades.py`: Added validation in `main()` that checks `RIDERSHIP_XLSX`, `AMENITIES_XLSX`, and `OUTPUT_FOLDER` before processing
  - `bay_usage_analyzer.py`: Added validation in `run_step2_conflict_detection()` that checks `BLOCK_OUTPUT_FOLDER` and `CLUSTER_CONFLICT_OUTPUT_FOLDER`

- **Deferred folder creation**: Moved `OUTPUT_FOLDER.mkdir()` call in `flag_stop_upgrades.py` from module initialization to after validation in `main()`, ensuring directories are only created when valid paths are configured

- **User-friendly warnings**: When placeholder paths are detected, scripts log a warning message instructing users to update the CONFIGURATION section and exit gracefully without processing

- **Completion logging**: Added success completion messages to both scripts for better visibility into execution flow

## Implementation Details

The validation checks are performed early in the execution flow before any file I/O operations. If any placeholder paths are detected, the scripts log a warning and return immediately, preventing accidental data processing with misconfigured paths.

https://claude.ai/code/session_016g5yVfKBCfooaxfbzqu6dm