### PR TITLE
ci(pre-commit): add ruff pre-commit hook to catch lint issues locally

### DIFF
--- a/.github/workflows/format-lint-autofix-weekly.yml
+++ b/.github/workflows/format-lint-autofix-weekly.yml
@@ -28,9 +28,8 @@ jobs:
     - name: Install Ruff + Ty + deps
       run: |
         python -m pip install --upgrade pip
-        pip install --pre "ruff>=0.4.0" ty
         [[ -f requirements.txt ]] && pip install -r requirements.txt
-        pip install pandas-stubs
+        pip install -r requirements-dev.txt
 
     - name: Ruff – format & lint repo
       run: |

--- a/.github/workflows/format-lint-typecheck.yml
+++ b/.github/workflows/format-lint-typecheck.yml
@@ -31,11 +31,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --pre "ruff>=0.4.0" ty
           if [[ -f requirements.txt ]]; then
             pip install -r requirements.txt
           fi
-          pip install pandas-stubs
+          pip install -r requirements-dev.txt
 
       - name: Check formatting with Ruff
         run: ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# Run locally with: pre-commit install (one-time), then on every commit.
+# Manually: pre-commit run --all-files
+#
+# Keep `rev` here in sync with the `ruff==` pin in requirements-dev.txt
+# so local hooks and CI use the same ruff version.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,17 @@ Many common issues are auto-corrected by Ruff on PRs.
 back to your PR branch automatically by the GitHub Actions workflow. While `ty` is configured to simply warn for
 many type mismatches, it *will* block/error on unresolved imports, unresolved references, and redundant casts.
 
+**Running ruff locally (optional but recommended):** install dev dependencies and enable the pre-commit hook to
+catch ruff issues before pushing, instead of waiting for a CI round-trip:
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+After this, `ruff check` and `ruff format` run automatically on every `git commit`. The hook reads its config
+from `pyproject.toml` and uses the same ruff version that CI does (pinned in `requirements-dev.txt`).
+
 ## 📁 File Organization
 
 - Add new scripts to the appropriate subfolder within `scripts/`, based on function (e.g., `ridership_tools/`, `gtfs_exports/`).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,9 @@ pytest==8.3.5                # Unit testing framework
 pytest-cov                   # Test coverage reporting
 
 # Linting & formatting
-ruff                         # Linting & formatting
+# Keep this version in sync with `rev` in .pre-commit-config.yaml.
+ruff==0.15.12                # Linting & formatting
+pre-commit                   # Local git hooks (ruff)
 
 # Type checking
 ty                           # Non-blocking type checks


### PR DESCRIPTION
## Summary
This PR adds pre-commit hook configuration to enable developers to run ruff linting and formatting checks locally before pushing code, reducing CI round-trips and improving the development workflow.

## Key Changes
- **Added `.pre-commit-config.yaml`**: Configures pre-commit hooks to automatically run `ruff check --fix` and `ruff format` on every commit
- **Updated `requirements-dev.txt`**: 
  - Pinned ruff to a specific version (0.15.12) with a comment to keep it in sync with `.pre-commit-config.yaml`
  - Added `pre-commit` as a dev dependency
- **Updated `CONTRIBUTING.md`**: Added instructions for developers to install dev dependencies and enable the pre-commit hook locally
- **Simplified CI workflows**: Updated both `format-lint-autofix-weekly.yml` and `format-lint-typecheck.yml` to install dependencies from `requirements-dev.txt` instead of manually specifying ruff and other tools, reducing duplication and ensuring consistency

## Notable Details
- The ruff version is explicitly pinned and documented to be kept in sync between `requirements-dev.txt` and `.pre-commit-config.yaml` to ensure local development and CI use the same version
- Pre-commit hooks are optional but recommended for developers
- CI workflows now have a single source of truth for dev dependencies, making maintenance easier

https://claude.ai/code/session_01X2SRAMAC4VSWjCEecr6jfR