### PR TITLE
ci: add commit message linting for conventional commits

### DIFF
--- a/.github/workflows/.pre-commit-config.yaml
+++ b/.github/workflows/.pre-commit-config.yaml
@@ -10,11 +10,3 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
-
-  - repo: local
-    hooks:
-      - id: lint-commit-msg
-        name: Lint commit message
-        language: python
-        entry: python dev_tools/lint_commit.py
-        stages: [commit-msg]

--- a/.github/workflows/.pre-commit-config.yaml
+++ b/.github/workflows/.pre-commit-config.yaml
@@ -10,3 +10,11 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: lint-commit-msg
+        name: Lint commit message
+        language: python
+        entry: python dev_tools/lint_commit.py
+        stages: [commit-msg]

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,0 +1,35 @@
+name: "Lint Commits"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  lint-commit-subjects:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate commit subjects
+        run: |
+          base="origin/${{ github.base_ref }}"
+          git fetch origin "${{ github.base_ref }}"
+          failed=0
+          while IFS= read -r subject; do
+            tmp=$(mktemp)
+            printf '%s\n' "$subject" > "$tmp"
+            python dev_tools/lint_commit.py "$tmp" || failed=1
+            rm "$tmp"
+          done < <(git log "$base"..HEAD --format=%s)
+          exit $failed

--- a/dev_tools/lint_commit.py
+++ b/dev_tools/lint_commit.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Lint a commit message subject line to ensure it follows Conventional Commits.
+
+Usage:
+    python lint_commit.py <commit-msg-file>
+
+The subject line (first line) must follow the format:
+    <type>(<scope>): <description>
+
+Where:
+    <type> is one of: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+    <scope> is optional, lowercase alphanumeric with hyphens
+    <description> starts with a lowercase letter
+
+Auto-generated subjects (Merge …, Revert "…") are skipped.
+"""
+
+import re
+import sys
+
+PATTERN = (
+    r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)"
+    r"(\([a-z0-9-]+\))?: [a-z].+$"
+)
+
+SKIP_PATTERN = r"^(Merge |Revert \")"
+
+
+def main() -> None:
+    """Validate the commit message subject from the file path argument."""
+    if len(sys.argv) < 2:
+        print("Error: No commit message file provided.")
+        sys.exit(1)
+
+    with open(sys.argv[1]) as f:
+        subject = f.readline().rstrip("\n")
+
+    if re.match(SKIP_PATTERN, subject):
+        print(f"Skipped: auto-generated commit '{subject}'.")
+        sys.exit(0)
+
+    if not re.match(PATTERN, subject):
+        print(f"Error: Commit subject '{subject}' does not follow Conventional Commits.")
+        print("Format: <type>(<scope>): <description>")
+        print("  - Types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test")
+        print("  - Scope: Optional, lowercase alphanumeric with hyphens (e.g., (scope))")
+        print("  - Description: Must start with a lowercase letter")
+        sys.exit(1)
+
+    print("Success: Commit subject is valid.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
This PR adds automated commit message validation to enforce the Conventional Commits specification across the project. It includes both a local pre-commit hook and a GitHub Actions workflow for CI validation.

## Key Changes
- **New linting tool** (`dev_tools/lint_commit.py`): A Python script that validates commit message subject lines against the Conventional Commits format
  - Enforces required format: `<type>(<scope>): <description>`
  - Supports 10 commit types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
  - Optional scope with lowercase alphanumeric characters and hyphens
  - Description must start with a lowercase letter
  - Automatically skips auto-generated commits (Merge, Revert)

- **GitHub Actions workflow** (`.github/workflows/lint-commits.yml`): Validates all commit subjects in pull requests
  - Runs on PR open, edit, reopen, and synchronize events
  - Checks commits between the base branch and PR head
  - Uses Python 3.12 for validation

- **Pre-commit hook configuration** (`.github/workflows/.pre-commit-config.yaml`): Adds local commit message validation
  - Runs at the commit-msg stage to catch violations before pushing
  - Integrates with the existing pre-commit setup

## Implementation Details
- The linting script uses regex patterns to validate format and skip auto-generated commits
- The GitHub Actions workflow fetches the base branch and iterates through new commits, validating each subject line
- Both local and CI validation use the same linting logic for consistency

https://claude.ai/code/session_01BydH4F33C37AsfK85UgBRU