### PR TITLE
feat(census-tools): add default-path guard and completion logging

### DIFF
--- a/scripts/census_tools/uscensus_blocks_merge_arcpy.py
+++ b/scripts/census_tools/uscensus_blocks_merge_arcpy.py
@@ -72,6 +72,10 @@ USE_IN_MEMORY: bool = True
 
 LOG_LEVEL: int = logging.INFO  # DEBUG / INFO / WARNING / ERROR
 
+# Sentinel values — detect un-edited placeholder paths
+_DEFAULT_INPUT_DIR: str = r"path\to\your\tiger_shapefiles"
+_DEFAULT_OUTPUT_PATH: str = r"output\va_md_dc_blocks_fips_merge.shp"
+
 
 # ArcPy can also echo messages to the GP window
 def _gp(msg: str, level: str = "info") -> None:
@@ -304,6 +308,18 @@ def main() -> None:
         format="%(asctime)s | %(levelname)s | %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
+
+    defaults_found = False
+    if INPUT_DIR == _DEFAULT_INPUT_DIR:
+        logging.warning("INPUT_DIR is still the placeholder value — update it before running.")
+        defaults_found = True
+    if OUTPUT_PATH == _DEFAULT_OUTPUT_PATH:
+        logging.warning("OUTPUT_PATH is still the placeholder value — update it before running.")
+        defaults_found = True
+    if defaults_found:
+        logging.info("No processing performed. Update the configuration paths and re-run.")
+        return
+
     try:
         shp_paths = discover_tiger_datasets(INPUT_DIR, INPUT_GLOB)
 

--- a/scripts/census_tools/uscensus_blocks_merge_gpd.py
+++ b/scripts/census_tools/uscensus_blocks_merge_gpd.py
@@ -71,6 +71,10 @@ OUTPUT_PATH: str = r"output\va_md_dc_blocks_fips_merge.shp"
 
 LOG_LEVEL: int = logging.INFO  # DEBUG / INFO / WARNING / ERROR
 
+# Sentinel values — detect un-edited placeholder paths
+_DEFAULT_INPUT_DIR: str = r"path\to\your\tiger_shapefiles"
+_DEFAULT_OUTPUT_PATH: str = r"output\va_md_dc_blocks_fips_merge.shp"
+
 # =============================================================================
 # FUNCTIONS
 # =============================================================================
@@ -271,6 +275,18 @@ def main() -> None:
         format="%(asctime)s | %(levelname)s | %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
+
+    defaults_found = False
+    if INPUT_DIR == _DEFAULT_INPUT_DIR:
+        logging.warning("INPUT_DIR is still the placeholder value — update it before running.")
+        defaults_found = True
+    if OUTPUT_PATH == _DEFAULT_OUTPUT_PATH:
+        logging.warning("OUTPUT_PATH is still the placeholder value — update it before running.")
+        defaults_found = True
+    if defaults_found:
+        logging.info("No processing performed. Update the configuration paths and re-run.")
+        return
+
     try:
         shp_paths = discover_tiger_datasets(INPUT_DIR, INPUT_GLOB, prefer="shp")
         merged = merge_shapefiles(shp_paths)

--- a/scripts/census_tools/uscensus_blocks_table_join_gpd.py
+++ b/scripts/census_tools/uscensus_blocks_table_join_gpd.py
@@ -11,6 +11,7 @@ No further data wrangling is performed here—just a clean spatial join.
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 from typing import Final, Literal
 
@@ -27,6 +28,11 @@ SHAPEFILE_PATH: Final[str] = r"PATH\TO\SHP\va_md_dc_blocks_fips_merge.shp"
 TABLE_CSV_PATH: Final[str] = r"PATH\TO\CSV\joined_blocks.csv"
 OUTPUT_PATH: Final[str] = r"PATH\TO\OUTPUT\va_md_dc_blocks_plus_data.shp"
 MAX_FIELD_LEN: Final[int] = 10  # Shapefile DBF column-name limit
+
+# Sentinel values — detect un-edited placeholder paths
+_DEFAULT_SHAPEFILE_PATH: str = r"PATH\TO\SHP\va_md_dc_blocks_fips_merge.shp"
+_DEFAULT_TABLE_CSV_PATH: str = r"PATH\TO\CSV\joined_blocks.csv"
+_DEFAULT_OUTPUT_PATH: str = r"PATH\TO\OUTPUT\va_md_dc_blocks_plus_data.shp"
 
 LEFT_KEY: Final[str] = "GEOID20"  # geometry field carrying the 15-digit ID
 RIGHT_KEY: Final[str] = "GEO_ID"  # CSV field carrying the 15-digit ID
@@ -219,11 +225,31 @@ def main() -> None:
         format="%(asctime)s | %(levelname)s | %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    blocks_gdf = load_blocks(SHAPEFILE_PATH)
-    attrs_df = load_attributes(TABLE_CSV_PATH)
 
-    joined = join_blocks_to_attributes(blocks_gdf, attrs_df)
-    save_output(joined, OUTPUT_PATH)
+    defaults_found = False
+    if SHAPEFILE_PATH == _DEFAULT_SHAPEFILE_PATH:
+        logging.warning("SHAPEFILE_PATH is still the placeholder value — update it before running.")
+        defaults_found = True
+    if TABLE_CSV_PATH == _DEFAULT_TABLE_CSV_PATH:
+        logging.warning("TABLE_CSV_PATH is still the placeholder value — update it before running.")
+        defaults_found = True
+    if OUTPUT_PATH == _DEFAULT_OUTPUT_PATH:
+        logging.warning("OUTPUT_PATH is still the placeholder value — update it before running.")
+        defaults_found = True
+    if defaults_found:
+        logging.info("No processing performed. Update the configuration paths and re-run.")
+        return
+
+    try:
+        blocks_gdf = load_blocks(SHAPEFILE_PATH)
+        attrs_df = load_attributes(TABLE_CSV_PATH)
+
+        joined = join_blocks_to_attributes(blocks_gdf, attrs_df)
+        save_output(joined, OUTPUT_PATH)
+        logging.info("Completed successfully.")
+    except Exception:  # noqa: BLE001
+        logging.exception("Processing failed")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/census_tools/uscensus_table_build.py
+++ b/scripts/census_tools/uscensus_table_build.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import io
 import logging
 import re
+import sys
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -68,6 +69,10 @@ TOPIC_SIGNATURES: dict[str, Sequence[str] | str] = {
 }
 
 LOG_LEVEL: int = logging.INFO  # DEBUG / INFO / WARNING / ERROR
+
+# Sentinel values — detect un-edited placeholder paths
+_DEFAULT_ROOT_DATA_DIR: str = r"Path\To\Your\Census_Table_Data_Files"
+_DEFAULT_CSV_OUTPUT_PATH: str = r"Path\To\Your\Output_Folder\joined_blocks.csv"
 
 # =============================================================================
 # FUNCTIONS
@@ -601,27 +606,47 @@ def main() -> None:
         format="%(asctime)s | %(levelname)s | %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    logging.info("Discovering Census datasets under %s …", ROOT_DATA_DIR)
-    discovered = discover_census_files(ROOT_DATA_DIR)
 
-    df_joined = build_joined_table(
-        pop_files=discovered["POP_FILES"],
-        hh_files=discovered["HH_FILES"],
-        jobs_files=discovered["JOBS_FILES"],
-        income_files=discovered["INCOME_FILES"],
-        ethnicity_files=discovered["ETHNICITY_FILES"],
-        language_files=discovered["LANGUAGE_FILES"],
-        vehicle_files=discovered["VEHICLE_FILES"],
-        age_files=discovered["AGE_FILES"],
-        county_fips_filter=COUNTY_FIPS_FILTER,
-    )
-    logging.info("Created DataFrame with shape %s", df_joined.shape)
+    defaults_found = False
+    if str(ROOT_DATA_DIR) == _DEFAULT_ROOT_DATA_DIR:
+        logging.warning("ROOT_DATA_DIR is still the placeholder value — update it before running.")
+        defaults_found = True
+    if CSV_OUTPUT_PATH == _DEFAULT_CSV_OUTPUT_PATH:
+        logging.warning(
+            "CSV_OUTPUT_PATH is still the placeholder value — update it before running."
+        )
+        defaults_found = True
+    if defaults_found:
+        logging.info("No processing performed. Update the configuration paths and re-run.")
+        return
 
-    if CSV_OUTPUT_PATH:
-        out_path = Path(CSV_OUTPUT_PATH).expanduser().resolve()
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        df_joined.to_csv(out_path, index=False)
-        logging.info("CSV written to %s", out_path)
+    try:
+        logging.info("Discovering Census datasets under %s …", ROOT_DATA_DIR)
+        discovered = discover_census_files(ROOT_DATA_DIR)
+
+        df_joined = build_joined_table(
+            pop_files=discovered["POP_FILES"],
+            hh_files=discovered["HH_FILES"],
+            jobs_files=discovered["JOBS_FILES"],
+            income_files=discovered["INCOME_FILES"],
+            ethnicity_files=discovered["ETHNICITY_FILES"],
+            language_files=discovered["LANGUAGE_FILES"],
+            vehicle_files=discovered["VEHICLE_FILES"],
+            age_files=discovered["AGE_FILES"],
+            county_fips_filter=COUNTY_FIPS_FILTER,
+        )
+        logging.info("Created DataFrame with shape %s", df_joined.shape)
+
+        if CSV_OUTPUT_PATH:
+            out_path = Path(CSV_OUTPUT_PATH).expanduser().resolve()
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            df_joined.to_csv(out_path, index=False)
+            logging.info("CSV written to %s", out_path)
+
+        logging.info("Completed successfully.")
+    except Exception:  # noqa: BLE001
+        logging.exception("Processing failed")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/census_tools/uscensus_tiger_join_arcpy.py
+++ b/scripts/census_tools/uscensus_tiger_join_arcpy.py
@@ -102,6 +102,15 @@ arcpy.env.overwriteOutput = True
 
 LOG_LEVEL: int = logging.INFO  # DEBUG / INFO / WARNING / ERROR
 
+# Sentinel values — detect un-edited placeholder paths
+_DEFAULT_INPUT_CSV_DIR: str = r"Folder\Path\To\Your\input_csvs"
+_DEFAULT_INPUT_SHP_DIR: str = r"Folder\Path\To\Your\input_shps"
+_DEFAULT_INTERMEDIATE_MERGED_SHP: str = "File/Path/To/Your/output_intermediate/merged_blocks.shp"
+_DEFAULT_INTERMEDIATE_COMBINED_CSV: str = (
+    r"File\Path\To\Your\output_intermediate\combined_blocks.csv"
+)
+_DEFAULT_FINAL_JOINED_FEATURES: str = "File/Path/To/Your/output_final/blocks_with_attrs.shp"
+
 
 def _gp(msg: str, level: str = "info") -> None:
     """Emit a message to ArcGIS geoprocessor console and Python logger."""
@@ -1161,6 +1170,33 @@ def run_pipeline() -> None:
         format="%(asctime)s | %(levelname)s | %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
+
+    defaults_found = False
+    if str(INPUT_CSV_DIR) == _DEFAULT_INPUT_CSV_DIR:
+        logging.warning("INPUT_CSV_DIR is still the placeholder value — update it before running.")
+        defaults_found = True
+    if str(INPUT_SHP_DIR) == _DEFAULT_INPUT_SHP_DIR:
+        logging.warning("INPUT_SHP_DIR is still the placeholder value — update it before running.")
+        defaults_found = True
+    if INTERMEDIATE_MERGED_SHP == _DEFAULT_INTERMEDIATE_MERGED_SHP:
+        logging.warning(
+            "INTERMEDIATE_MERGED_SHP is still the placeholder value — update it before running."
+        )
+        defaults_found = True
+    if INTERMEDIATE_COMBINED_CSV == _DEFAULT_INTERMEDIATE_COMBINED_CSV:
+        logging.warning(
+            "INTERMEDIATE_COMBINED_CSV is still the placeholder value — update it before running."
+        )
+        defaults_found = True
+    if FINAL_JOINED_FEATURES == _DEFAULT_FINAL_JOINED_FEATURES:
+        logging.warning(
+            "FINAL_JOINED_FEATURES is still the placeholder value — update it before running."
+        )
+        defaults_found = True
+    if defaults_found:
+        logging.info("No processing performed. Update the configuration paths and re-run.")
+        return
+
     try:
         # 1) CSV stage: build combined attributes
         logging.info("Discovering & merging CSVs under %s ...", INPUT_CSV_DIR)


### PR DESCRIPTION
## Summary
Added configuration validation and comprehensive error handling to all five census processing scripts. Each script now detects when configuration paths remain at their placeholder values and prevents execution until they are properly configured. Additionally, all main processing logic is now wrapped in try-except blocks with proper logging and exit codes.

## Key Changes

- **Configuration Validation**: Added sentinel constant values for each placeholder path in all scripts (`_DEFAULT_*` constants). The `main()` function now checks if any configuration paths match these defaults and logs warnings before exiting.

- **Early Exit on Misconfiguration**: If any placeholder paths are detected, the script logs an informational message and returns early without attempting to process data, preventing silent failures or errors on invalid paths.

- **Error Handling**: Wrapped all main processing logic in try-except blocks that:
  - Catch any exceptions during execution
  - Log the full exception traceback using `logging.exception()`
  - Exit with status code 1 on failure

- **Import Additions**: Added `import sys` to scripts that needed it for `sys.exit(1)` calls.

- **Success Logging**: Added "Completed successfully." log message at the end of successful processing.

## Files Modified
- `uscensus_table_build.py`
- `uscensus_blocks_table_join_gpd.py`
- `uscensus_tiger_join_arcpy.py`
- `uscensus_blocks_merge_arcpy.py`
- `uscensus_blocks_merge_gpd.py`

## Implementation Details
The validation pattern is consistent across all scripts:
1. Define sentinel values matching the placeholder paths in configuration
2. Check each configuration variable against its sentinel value
3. Log a warning for each misconfigured path
4. Exit early if any defaults are found
5. Wrap processing in try-except with proper logging and exit codes

This prevents accidental data processing with invalid paths and provides clear feedback to users about what needs to be configured.

https://claude.ai/code/session_017kmenMJAhFgsjTHLAhx2YM